### PR TITLE
Add GCP inspector service account for InsideOut

### DIFF
--- a/tf/cloud-provision/inspector.tf
+++ b/tf/cloud-provision/inspector.tf
@@ -1,11 +1,18 @@
-# InsideOut Inspector Role (AWS only)
+# InsideOut Inspector Role
 #
-# This role allows the InsideOut service to inspect deployed AWS resources
-# with read-only access. It trusts the Terraform service account role,
-# which is used by the Oracle portal via a double-hop AssumeRole.
+# This file creates read-only inspector credentials for InsideOut:
+# - AWS: IAM role that trusts the Terraform SA role (double-hop AssumeRole)
+# - GCP: Service account with viewer permissions (token impersonation)
 
 locals {
+  # AWS inspector role name
   inspector_role_name = "insideout-inspector-${var.project_id}"
+
+  # GCP inspector service account ID (max 30 chars, lowercase, hyphens allowed)
+  gcp_inspector_sa_id = "insideout-inspector-${var.short_project_id}"
+
+  # Extract deployment SA email from credentials for token creator binding
+  gcp_deployment_sa_email = local.is_gcp ? jsondecode(base64decode(var.gcp_credentials_b64)).client_email : ""
 }
 
 data "aws_iam_policy_document" "inspector_assume" {
@@ -46,6 +53,61 @@ resource "aws_iam_role_policy_attachment" "inspector_readonly" {
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
+# ============================================================================
+# GCP Inspector Service Account (only created when cloud_provider = gcp)
+# ============================================================================
+
+# Create a dedicated read-only service account for inspection
+resource "google_service_account" "insideout_inspector" {
+  count = local.is_gcp ? 1 : 0
+
+  account_id   = local.gcp_inspector_sa_id
+  display_name = "InsideOut Inspector - ${var.project_id}"
+  description  = "Read-only service account for InsideOut infrastructure inspection"
+  project      = var.gcp_project_id
+}
+
+# Grant Viewer role (read-only access to most resources)
+resource "google_project_iam_member" "inspector_viewer" {
+  count = local.is_gcp ? 1 : 0
+
+  project = var.gcp_project_id
+  role    = "roles/viewer"
+  member  = "serviceAccount:${google_service_account.insideout_inspector[0].email}"
+}
+
+# Grant Storage Object Viewer for GCS bucket contents
+resource "google_project_iam_member" "inspector_storage_viewer" {
+  count = local.is_gcp ? 1 : 0
+
+  project = var.gcp_project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.insideout_inspector[0].email}"
+}
+
+# Grant Secret Manager Viewer for secret metadata (not values)
+resource "google_project_iam_member" "inspector_secretmanager_viewer" {
+  count = local.is_gcp ? 1 : 0
+
+  project = var.gcp_project_id
+  role    = "roles/secretmanager.viewer"
+  member  = "serviceAccount:${google_service_account.insideout_inspector[0].email}"
+}
+
+# Allow the deployment SA to generate tokens for the inspector SA
+# This enables Oracle to impersonate the inspector SA for read-only access
+resource "google_service_account_iam_member" "inspector_token_creator" {
+  count = local.is_gcp ? 1 : 0
+
+  service_account_id = google_service_account.insideout_inspector[0].name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${local.gcp_deployment_sa_email}"
+}
+
+# ============================================================================
+# Outputs
+# ============================================================================
+
 output "inspector_role_arn" {
   description = "ARN of the InsideOut inspector role (AWS only)"
   value       = local.is_aws ? aws_iam_role.insideout_inspector[0].arn : ""
@@ -54,6 +116,16 @@ output "inspector_role_arn" {
 output "inspector_role_name" {
   description = "Name of the InsideOut inspector role (AWS only)"
   value       = local.is_aws ? aws_iam_role.insideout_inspector[0].name : ""
+}
+
+output "gcp_inspector_sa_email" {
+  description = "Email of the GCP inspector service account (GCP only)"
+  value       = local.is_gcp ? google_service_account.insideout_inspector[0].email : ""
+}
+
+output "gcp_inspector_sa_id" {
+  description = "ID of the GCP inspector service account (GCP only)"
+  value       = local.is_gcp ? google_service_account.insideout_inspector[0].account_id : ""
 }
 
 


### PR DESCRIPTION
## Summary

Adds a GCP service account parallel to the existing AWS inspector role, providing read-only access for InsideOut infrastructure inspection.

## Changes

### New GCP Resources in `tf/cloud-provision/inspector.tf`

| Resource | Role/Purpose |
|----------|--------------|
| `google_service_account.insideout_inspector` | Dedicated read-only service account |
| `google_project_iam_member.inspector_viewer` | `roles/viewer` - read access to most resources |
| `google_project_iam_member.inspector_storage_viewer` | `roles/storage.objectViewer` - read GCS contents |
| `google_project_iam_member.inspector_secretmanager_viewer` | `roles/secretmanager.viewer` - view secret metadata |
| `google_service_account_iam_member.inspector_token_creator` | Allows deployment SA to impersonate inspector SA |

### New Outputs

| Output | Description |
|--------|-------------|
| `gcp_inspector_sa_email` | Email of the inspector service account |
| `gcp_inspector_sa_id` | Account ID of the inspector service account |

## How It Works

```
┌─────────────────────────────────────────────────────────────────┐
│                        Oracle Service                           │
│  Uses deployment SA (gcp_credentials_b64) to call               │
│  GenerateAccessToken for inspector SA                           │
└────────────────────────────┬────────────────────────────────────┘
                             │
                             ▼
┌─────────────────────────────────────────────────────────────────┐
│                    GCP IAM Credentials API                      │
│  GenerateAccessToken(insideout-inspector-{short_project_id})    │
└────────────────────────────┬────────────────────────────────────┘
                             │
                             ▼
┌─────────────────────────────────────────────────────────────────┐
│              Short-lived Access Token (1 hour)                  │
│  Identity: inspector SA (read-only permissions)                 │
└─────────────────────────────────────────────────────────────────┘
```

## Deterministic Naming

The inspector SA email can be derived without reading terraform state:

```
insideout-inspector-{short_project_id}@{gcp_project_id}.iam.gserviceaccount.com
```

## Backward Compatibility

- All GCP resources are conditional on `cloud_provider = "gcp"`
- AWS deployments are unaffected
- Existing outputs remain unchanged

## Test Plan

- [ ] AWS deployment continues to work (regression)
- [ ] GCP deployment creates inspector service account
- [ ] Inspector SA has correct IAM bindings
- [ ] Deployment SA can generate tokens for inspector SA
- [ ] Token grants read-only access to GCP resources