### PR TITLE
Add Cloud Run viewer role to inspector service account

### DIFF
--- a/tf/cloud-provision/inspector.tf
+++ b/tf/cloud-provision/inspector.tf
@@ -94,6 +94,15 @@ resource "google_project_iam_member" "inspector_secretmanager_viewer" {
   member  = "serviceAccount:${google_service_account.insideout_inspector[0].email}"
 }
 
+# Grant Cloud Run Viewer for inspecting Cloud Run services
+resource "google_project_iam_member" "inspector_run_viewer" {
+  count = local.is_gcp ? 1 : 0
+
+  project = var.gcp_project_id
+  role    = "roles/run.viewer"
+  member  = "serviceAccount:${google_service_account.insideout_inspector[0].email}"
+}
+
 # Allow the deployment SA to generate tokens for the inspector SA
 # This enables Oracle to impersonate the inspector SA for read-only access
 resource "google_service_account_iam_member" "inspector_token_creator" {


### PR DESCRIPTION
Fixes #5

Adds `roles/run.viewer` to the GCP inspector service account to enable Cloud Run inspection in InsideOut.

## Changes

- Added `google_project_iam_member.inspector_run_viewer` resource
- Grants `roles/run.viewer` to the inspector service account
- Enables `list-services` and `describe-service` actions for Cloud Run inspection

## Validation

- Terraform validate: ✅ Success