### PR TITLE
feat: add external_id to assume_role blocks for confused-deputy protection

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -100,3 +100,4 @@ jobs:
         run: |
           bash tests/test-prepare-custom-stack.sh
           bash tests/test-tf-destroy-init.sh
+          bash tests/test-external-id.sh

--- a/tests/test-external-id.sh
+++ b/tests/test-external-id.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validates that every assume_role block in providers.tf includes external_id.
+# This prevents regressions where new providers are added without
+# confused-deputy protection.
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TF_DIR="$SCRIPT_DIR/tf"
+
+# Find all providers.tf files across stages
+while IFS= read -r providers_file; do
+  stage="$(basename "$(dirname "$providers_file")")"
+
+  # Count assume_role blocks and external_id lines within them
+  assume_role_count="$(grep -c 'assume_role {' "$providers_file" || true)"
+  external_id_count="$(grep -c 'external_id' "$providers_file" || true)"
+
+  if [[ "$assume_role_count" -eq 0 ]]; then
+    pass "$stage/providers.tf: no assume_role blocks (nothing to check)"
+    continue
+  fi
+
+  if [[ "$external_id_count" -eq "$assume_role_count" ]]; then
+    pass "$stage/providers.tf: all $assume_role_count assume_role block(s) have external_id"
+  else
+    fail "$stage/providers.tf: found $assume_role_count assume_role block(s) but only $external_id_count external_id line(s)"
+  fi
+done < <(find "$TF_DIR" -name providers.tf -type f | sort)
+
+# Verify aws_external_id variable is declared in each stage that uses assume_role
+echo ""
+echo "Checking aws_external_id variable declarations..."
+
+while IFS= read -r providers_file; do
+  stage_dir="$(dirname "$providers_file")"
+  stage="$(basename "$stage_dir")"
+
+  assume_role_count="$(grep -c 'assume_role {' "$providers_file" || true)"
+  [[ "$assume_role_count" -eq 0 ]] && continue
+
+  # Search all .tf files in the stage for the variable declaration
+  if grep -rq 'variable "aws_external_id"' "$stage_dir"/*.tf 2>/dev/null; then
+    pass "$stage: aws_external_id variable declared"
+  else
+    fail "$stage: aws_external_id variable NOT declared (but assume_role blocks exist)"
+  fi
+done < <(find "$TF_DIR" -name providers.tf -type f | sort)
+
+# --- Summary ---
+echo ""
+echo "================================"
+echo "  $PASS passed, $FAIL failed"
+echo "================================"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tf/account-provision/providers.tf
+++ b/tf/account-provision/providers.tf
@@ -11,5 +11,6 @@ provider "aws" {
   assume_role {
     role_arn     = var.org_creator_role_arn
     session_name = "terraform-org-creator"
+    external_id  = var.aws_external_id != "" ? var.aws_external_id : null
   }
 }

--- a/tf/account-provision/vars.tf
+++ b/tf/account-provision/vars.tf
@@ -45,3 +45,9 @@ variable "org_creator_role_arn" {
   description = "ARN of the org-creator role (in root account) to assume when creating new AWS accounts"
   type        = string
 }
+
+variable "aws_external_id" {
+  description = "ExternalId for confused-deputy protection when assuming cross-account roles"
+  type        = string
+  default     = ""
+}

--- a/tf/account-setup/providers.tf
+++ b/tf/account-setup/providers.tf
@@ -4,5 +4,6 @@ provider "aws" {
   assume_role {
     role_arn     = "arn:aws:iam::${var.account_id}:role/${var.account_bootstrap_role_name}"
     session_name = "terraform-account-setup"
+    external_id  = var.aws_external_id != "" ? var.aws_external_id : null
   }
 }

--- a/tf/account-setup/vars.tf
+++ b/tf/account-setup/vars.tf
@@ -35,3 +35,9 @@ variable "additional_terraform_sa_roles" {
   type        = list(string)
   default     = []
 }
+
+variable "aws_external_id" {
+  description = "ExternalId for confused-deputy protection when assuming cross-account roles"
+  type        = string
+  default     = ""
+}

--- a/tf/cloud-provision/providers.tf
+++ b/tf/cloud-provision/providers.tf
@@ -6,7 +6,8 @@ provider "aws" {
   region = var.cloud_provider == "aws" ? var.aws_region : "us-west-2"
 
   assume_role {
-    role_arn = var.cloud_provider == "aws" ? var.bootstrap_role : null
+    role_arn    = var.cloud_provider == "aws" ? var.bootstrap_role : null
+    external_id = var.cloud_provider == "aws" ? var.aws_external_id : null
   }
 }
 

--- a/tf/cloud-provision/vars.tf
+++ b/tf/cloud-provision/vars.tf
@@ -76,6 +76,12 @@ variable "bootstrap_role" {
   default     = ""
 }
 
+variable "aws_external_id" {
+  description = "ExternalId for confused-deputy protection when assuming cross-account roles"
+  type        = string
+  default     = ""
+}
+
 # ============================================================================
 # GCP Variables (required when cloud_provider = gcp)
 # ============================================================================

--- a/tf/custom-stack-provision/__customer_state_inputs.tf
+++ b/tf/custom-stack-provision/__customer_state_inputs.tf
@@ -118,6 +118,12 @@ variable "bootstrap_role" {
   default     = ""
 }
 
+variable "aws_external_id" {
+  description = "ExternalId for confused-deputy protection when assuming cross-account roles"
+  type        = string
+  default     = ""
+}
+
 # ============================================================================
 # EKS Variables (AWS defaults, passed but may not be used)
 # ============================================================================

--- a/tf/custom-stack-provision/providers.tf
+++ b/tf/custom-stack-provision/providers.tf
@@ -19,7 +19,8 @@ terraform {
 provider "aws" {
   region = var.cloud_provider == "aws" ? var.aws_region : "us-west-2"
   assume_role {
-    role_arn = var.cloud_provider == "aws" ? local.terraform_role_arn : null
+    role_arn    = var.cloud_provider == "aws" ? local.terraform_role_arn : null
+    external_id = var.cloud_provider == "aws" ? var.aws_external_id : null
   }
 }
 
@@ -28,7 +29,8 @@ provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
   assume_role {
-    role_arn = var.cloud_provider == "aws" ? local.terraform_role_arn : null
+    role_arn    = var.cloud_provider == "aws" ? local.terraform_role_arn : null
+    external_id = var.cloud_provider == "aws" ? var.aws_external_id : null
   }
 }
 

--- a/tf/k8s-provision/providers.tf
+++ b/tf/k8s-provision/providers.tf
@@ -2,7 +2,8 @@ provider "aws" {
   region = var.aws_region
 
   assume_role {
-    role_arn = local.terraform_role_arn
+    role_arn    = local.terraform_role_arn
+    external_id = var.aws_external_id != "" ? var.aws_external_id : null
   }
 }
 

--- a/tf/k8s-provision/vars.tf
+++ b/tf/k8s-provision/vars.tf
@@ -44,3 +44,9 @@ variable "luther_project_name" {
   type    = string
   default = "app"
 }
+
+variable "aws_external_id" {
+  description = "ExternalId for confused-deputy protection when assuming cross-account roles"
+  type        = string
+  default     = ""
+}

--- a/tf/vm-provision/providers.tf
+++ b/tf/vm-provision/providers.tf
@@ -2,7 +2,8 @@ provider "aws" {
   region = var.aws_region
 
   assume_role {
-    role_arn = local.terraform_role_arn
+    role_arn    = local.terraform_role_arn
+    external_id = var.aws_external_id != "" ? var.aws_external_id : null
   }
 }
 
@@ -11,7 +12,8 @@ provider "aws" {
   region = "us-east-1"
 
   assume_role {
-    role_arn = local.terraform_role_arn
+    role_arn    = local.terraform_role_arn
+    external_id = var.aws_external_id != "" ? var.aws_external_id : null
   }
 }
 

--- a/tf/vm-provision/vars.tf
+++ b/tf/vm-provision/vars.tf
@@ -58,3 +58,9 @@ variable "repo_name" {
 variable "repo_org" {
   type = string
 }
+
+variable "aws_external_id" {
+  description = "ExternalId for confused-deputy protection when assuming cross-account roles"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- Declares `aws_external_id` variable (default `""`) in all 6 Terraform stages
- Adds `external_id` to every `assume_role` block in `providers.tf` files
- AWS-only stages use `!= "" ? val : null` guard; dual-cloud stages use `cloud_provider == "aws" ?` guard
- Passing `null` is harmless for legacy roles without the `sts:ExternalId` condition

## Context

The InsideOut Quick-Create CloudFormation template creates customer IAM roles with an `sts:ExternalId` condition for confused-deputy protection. Oracle already passes `aws_external_id` through tfvars, but no Terraform provider `assume_role` block uses it — causing `AccessDenied` when assuming roles created via Quick-Create.

## Files changed

| Stage | Files |
|-------|-------|
| account-provision | `vars.tf`, `providers.tf` |
| account-setup | `vars.tf`, `providers.tf` |
| cloud-provision | `vars.tf`, `providers.tf` |
| vm-provision | `vars.tf`, `providers.tf` |
| k8s-provision | `vars.tf`, `providers.tf` |
| custom-stack-provision | `__customer_state_inputs.tf`, `providers.tf` |
| CI | `.github/workflows/validate.yml` |
| Tests | `tests/test-external-id.sh` (new) |

## Test plan

- [x] New `test-external-id.sh` passes locally (12/12)
- [x] Existing `test-prepare-custom-stack.sh` passes (no regressions)
- [x] `terraform fmt -check -recursive` passes
- [x] `shellcheck` passes on new test script
- [ ] CI `terraform validate` on all 6 stages
- [ ] CI `terraform fmt` check
- [ ] CI shell lint + tests

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)