### PR TITLE
fix: treat empty aws_external_id as null to prevent provider error

### DIFF
--- a/tf/cloud-provision/providers.tf
+++ b/tf/cloud-provision/providers.tf
@@ -7,7 +7,7 @@ provider "aws" {
 
   assume_role {
     role_arn    = var.cloud_provider == "aws" ? var.bootstrap_role : null
-    external_id = var.cloud_provider == "aws" ? var.aws_external_id : null
+    external_id = var.cloud_provider == "aws" && var.aws_external_id != "" ? var.aws_external_id : null
   }
 }
 

--- a/tf/custom-stack-provision/providers.tf
+++ b/tf/custom-stack-provision/providers.tf
@@ -20,7 +20,7 @@ provider "aws" {
   region = var.cloud_provider == "aws" ? var.aws_region : "us-west-2"
   assume_role {
     role_arn    = var.cloud_provider == "aws" ? local.terraform_role_arn : null
-    external_id = var.cloud_provider == "aws" ? var.aws_external_id : null
+    external_id = var.cloud_provider == "aws" && var.aws_external_id != "" ? var.aws_external_id : null
   }
 }
 
@@ -30,7 +30,7 @@ provider "aws" {
   region = "us-east-1"
   assume_role {
     role_arn    = var.cloud_provider == "aws" ? local.terraform_role_arn : null
-    external_id = var.cloud_provider == "aws" ? var.aws_external_id : null
+    external_id = var.cloud_provider == "aws" && var.aws_external_id != "" ? var.aws_external_id : null
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix cloud-provision and custom-stack-provision providers.tf to treat empty `aws_external_id` as `null` instead of `""`
- The AWS provider rejects `external_id=""` with: `expected length of assume_role.0.external_id to be in the range (2 - 1224), got`
- Other stages (k8s-provision, vm-provision, account-provision, account-setup) already had the correct `!= ""` check — this aligns the remaining two

## Test plan

- [x] `tests/test-external-id.sh` passes (12/12)
- [ ] Re-run a deploy without ExternalId (access-key auth) to confirm no regression
- [ ] Re-run a deploy with ExternalId (role-arn + CFN Quick-Create) to confirm it flows through

🤖 Generated with [Claude Code](https://claude.com/claude-code)