### PR TITLE
fix: rename SCRIPT_DIR to _BOOTSTRAP_DIR in bootstrap.sh scripts

### DIFF
--- a/tf/account-provision/bootstrap.sh
+++ b/tf/account-provision/bootstrap.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-: "${MARS_PROJECT_ROOT:=$(cd "$SCRIPT_DIR/.." && pwd)}"
+_BOOTSTRAP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MARS_PROJECT_ROOT:=$(cd "$_BOOTSTRAP_DIR/.." && pwd)}"
 
 # Source helpers
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 
 # Source shared terraform helpers
-source "${SCRIPT_DIR}/../../shell_utils.sh"
+source "${_BOOTSTRAP_DIR}/../../shell_utils.sh"
 
 tfBootstrap() {
   # if we’ve already-generated a backend file, skip

--- a/tf/account-setup/bootstrap.sh
+++ b/tf/account-setup/bootstrap.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-: "${MARS_PROJECT_ROOT:=$(cd "$SCRIPT_DIR/.." && pwd)}"
+_BOOTSTRAP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MARS_PROJECT_ROOT:=$(cd "$_BOOTSTRAP_DIR/.." && pwd)}"
 
 # Source helpers
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 
 # Source shared terraform helpers
-source "${SCRIPT_DIR}/../../shell_utils.sh"
+source "${_BOOTSTRAP_DIR}/../../shell_utils.sh"
 
 JUMP_ROLE_ARN="$(mustGetTfVar "org_creator_role_arn")"
 export JUMP_ROLE_ARN

--- a/tf/cloud-provision/bootstrap.sh
+++ b/tf/cloud-provision/bootstrap.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-: "${MARS_PROJECT_ROOT:=$(cd "$SCRIPT_DIR/.." && pwd)}"
+_BOOTSTRAP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MARS_PROJECT_ROOT:=$(cd "$_BOOTSTRAP_DIR/.." && pwd)}"
 
 # Source helpers
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 
 # Source shared terraform helpers
-source "${SCRIPT_DIR}/../../shell_utils.sh"
+source "${_BOOTSTRAP_DIR}/../../shell_utils.sh"
 
 tfBootstrap() {
   if [ -f "backend.tf.json" ]; then


### PR DESCRIPTION
## Summary
- Renames `SCRIPT_DIR` → `_BOOTSTRAP_DIR` in all 3 `bootstrap.sh` files (`account-provision`, `account-setup`, `cloud-provision`)
- Fixes the variable clobber that breaks `apply-plan.sh`, `drift-refresh.sh`, and `apply-with-outputs.sh` when they reference `$SCRIPT_DIR` after sourcing `utils.sh`

Closes #32

## Test plan
- [x] `bash -n` syntax check passes on all 3 files
- [x] `shellcheck` reports no new warnings (only pre-existing SC1091)
- [x] No remaining `SCRIPT_DIR` references in any `bootstrap.sh` file
- [x] `_BOOTSTRAP_DIR` only exists in the 3 bootstrap files (no conflicts)

---
*Local validation passed. Security review completed (mechanical rename, no new logic). No test files modified — QA professor review skipped.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>