### PR TITLE
fix: consolidate credential setup into shell_utils.sh

### DIFF
--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -303,6 +303,65 @@ cleanupGCPCredentials() {
 }
 
 # ============================================================================
+# Dummy GCP Credentials (for non-GCP environments)
+# ============================================================================
+
+# Temporary file path for dummy GCP credentials
+_GCP_DUMMY_CREDENTIALS_FILE=""
+
+# _setupDummyGCPCredentials creates a minimal service account JSON so the
+# Google Terraform provider doesn't fail looking for Application Default
+# Credentials.  Only needed when cloud_provider != gcp.
+_setupDummyGCPCredentials() {
+  _GCP_DUMMY_CREDENTIALS_FILE=$(mktemp /tmp/gcp-dummy-XXXXXX.json)
+  chmod 600 "$_GCP_DUMMY_CREDENTIALS_FILE"
+
+  local dummy_key
+  dummy_key=$(head -c 256 /dev/urandom 2>/dev/null | base64 | tr -d '\n' || echo "dW51c2VkCg==")
+
+  cat > "$_GCP_DUMMY_CREDENTIALS_FILE" <<EOFCREDS
+{"type":"service_account","project_id":"unused","private_key_id":"unused","private_key":"-----BEGIN PRIVATE KEY-----\n${dummy_key}\n-----END PRIVATE KEY-----\n","client_email":"unused@unused.iam.gserviceaccount.com","client_id":"0","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token"}
+EOFCREDS
+
+  export GOOGLE_APPLICATION_CREDENTIALS="$_GCP_DUMMY_CREDENTIALS_FILE"
+  echo "Dummy GCP credentials configured: $GOOGLE_APPLICATION_CREDENTIALS"
+}
+
+# _cleanupDummyGCPCredentials removes the temporary dummy credential file
+_cleanupDummyGCPCredentials() {
+  if [[ -n "$_GCP_DUMMY_CREDENTIALS_FILE" ]] && [[ -f "$_GCP_DUMMY_CREDENTIALS_FILE" ]]; then
+    rm -f "$_GCP_DUMMY_CREDENTIALS_FILE"
+    echo "Cleaned up dummy GCP credentials file"
+  fi
+  _GCP_DUMMY_CREDENTIALS_FILE=""
+}
+
+# ============================================================================
+# AWS Jump Role
+# ============================================================================
+
+# assumeJumpRole assumes the role specified by JUMP_ROLE_ARN (if set).
+# Exports temporary AWS credentials for the assumed role.
+assumeJumpRole() {
+  if [[ -z "${JUMP_ROLE_ARN:-}" ]]; then
+    return 0
+  fi
+
+  echo "Assuming jump role: $JUMP_ROLE_ARN"
+  local creds_json
+  creds_json=$(aws sts assume-role \
+    --role-arn "$JUMP_ROLE_ARN" \
+    --role-session-name "mars-jump-session" \
+    --output json)
+
+  AWS_ACCESS_KEY_ID=$(echo "$creds_json" | jq -r .Credentials.AccessKeyId)
+  AWS_SECRET_ACCESS_KEY=$(echo "$creds_json" | jq -r .Credentials.SecretAccessKey)
+  AWS_SESSION_TOKEN=$(echo "$creds_json" | jq -r .Credentials.SessionToken)
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+  echo "Now running under assumed jump role credentials"
+}
+
+# ============================================================================
 # Cloud Environment Setup
 # ============================================================================
 
@@ -347,9 +406,11 @@ setupCloudEnv() {
       ;;
 
     aws)
-      # AWS uses IRSA (IAM Roles for Service Accounts) - no additional setup needed
-      # The pod's service account already has the required IAM role attached
-      echo "AWS environment: using IRSA (no additional setup required)"
+      # AWS uses IRSA (IAM Roles for Service Accounts) for AWS auth.
+      # Create dummy GCP credentials so the Google provider doesn't fail
+      # looking for Application Default Credentials.
+      echo "AWS environment: using IRSA"
+      _setupDummyGCPCredentials
       ;;
 
     *)
@@ -357,6 +418,9 @@ setupCloudEnv() {
       return 1
       ;;
   esac
+
+  # Handle AWS jump role assumption (applies to all providers)
+  assumeJumpRole
 
   return 0
 }
@@ -372,7 +436,7 @@ cleanupCloudEnv() {
       cleanupGCPCredentials
       ;;
     aws)
-      # No cleanup needed for AWS
+      _cleanupDummyGCPCredentials
       ;;
   esac
 }

--- a/tests/test-apply-scripts.sh
+++ b/tests/test-apply-scripts.sh
@@ -32,7 +32,7 @@ cat > "$PROJECT/ansible/inventories/default/group_vars/all/env.yaml" <<'EOF'
 environment: test
 EOF
 
-echo '{}' > "$PROJECT/tf/auto-vars/common.auto.tfvars.json"
+echo '{"cloud_provider": "aws"}' > "$PROJECT/tf/auto-vars/common.auto.tfvars.json"
 
 # Copy real scripts
 cp "$REPO_ROOT/shell_utils.sh" "$PROJECT/shell_utils.sh"

--- a/tf/apply-plan.sh
+++ b/tf/apply-plan.sh
@@ -58,6 +58,9 @@ export MARS_PROJECT_ROOT
 set -- "$lifecycle"
 . "$SCRIPT_DIR/utils.sh"
 
+setupCloudEnv
+trap 'cleanupCloudEnv' EXIT
+
 plan_file="${plan_id}.tfplan"
 
 if [[ ! -f "$plan_file" ]]; then

--- a/tf/apply-with-outputs.sh
+++ b/tf/apply-with-outputs.sh
@@ -57,6 +57,9 @@ if [[ "$check_drift" == "true" ]]; then
   set -- "$lifecycle"
   . "$SCRIPT_DIR/utils.sh"
 
+  setupCloudEnv
+  trap 'cleanupCloudEnv' EXIT
+
   terraform init -input=false
   terraform plan -out=apply.tfplan -input=false
 
@@ -78,6 +81,9 @@ else
   . "$MARS_PROJECT_ROOT/shell_utils.sh"
   set -- "$lifecycle"
   . "$SCRIPT_DIR/utils.sh"
+
+  setupCloudEnv
+  trap 'cleanupCloudEnv' EXIT
 
   captureOutputs
 fi

--- a/tf/drift-refresh.sh
+++ b/tf/drift-refresh.sh
@@ -31,6 +31,9 @@ export MARS_PROJECT_ROOT
 set -- "$lifecycle"
 . "$SCRIPT_DIR/utils.sh"
 
+setupCloudEnv
+trap 'cleanupCloudEnv' EXIT
+
 # Run terraform init and refresh-only plan
 terraform init -input=false
 terraform plan -refresh-only -out=refresh.tfplan -input=false

--- a/tf/run-with-creds.sh
+++ b/tf/run-with-creds.sh
@@ -1,66 +1,19 @@
 #!/usr/bin/env bash
 
-# Source shell utilities for cloud provider detection
+# Credential wrapper for the Mars CLI runner.
+# Sets up cloud-specific credentials (GCP real or dummy, AWS jump role)
+# then hands off to the real Mars runner.
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../shell_utils.sh"
 
-# Setup cloud-specific credentials
-if isGCP; then
-  echo "🔐 Setting up GCP credentials"
-  if ! setupGCPCredentials; then
-    echo "❌ Failed to setup GCP credentials" >&2
-    exit 1
-  fi
-  trap 'cleanupGCPCredentials' EXIT
-
-  # Export GCP project and region
-  gcp_project=$(getTfVar "gcp_project_id")
-  gcp_region=$(getTfVar "gcp_region")
-
-  if [[ -z "$gcp_project" || "$gcp_project" == "null" ]]; then
-    echo "❌ ERROR: gcp_project_id not found in tfvars" >&2
-    exit 1
-  fi
-
-  if [[ -z "$gcp_region" || "$gcp_region" == "null" ]]; then
-    echo "❌ ERROR: gcp_region not found in tfvars" >&2
-    exit 1
-  fi
-
-  export GOOGLE_PROJECT="$gcp_project"
-  export GOOGLE_REGION="$gcp_region"
-
-  echo "✅ GCP environment configured:"
-  echo "   GOOGLE_PROJECT=$GOOGLE_PROJECT"
-  echo "   GOOGLE_REGION=$GOOGLE_REGION"
-
-else
-  # AWS/other: Create dummy GCP credentials at runtime to prevent Google provider
-  # from trying to load Application Default Credentials (which fails in non-GCP envs)
-  _GCP_DUMMY_FILE=$(mktemp /tmp/gcp-dummy-XXXXXX.json)
-  # Generate random bytes for the dummy key field (runtime-only, never stored in git)
-  _DUMMY_KEY=$(head -c 256 /dev/urandom 2>/dev/null | base64 | tr -d '\n' || echo "dW51c2VkCg==")
-  cat > "$_GCP_DUMMY_FILE" << EOFCREDS
-{"type":"service_account","project_id":"unused","private_key_id":"unused","private_key":"-----BEGIN PRIVATE KEY-----\n${_DUMMY_KEY}\n-----END PRIVATE KEY-----\n","client_email":"unused@unused.iam.gserviceaccount.com","client_id":"0","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token"}
-EOFCREDS
-  export GOOGLE_APPLICATION_CREDENTIALS="$_GCP_DUMMY_FILE"
-  trap 'rm -f "$_GCP_DUMMY_FILE"' EXIT
+if ! setupCloudEnv; then
+  echo "Failed to setup cloud environment" >&2
+  exit 1
 fi
+trap 'cleanupCloudEnv' EXIT
 
-# Handle AWS jump role if set
-if [ -n "${JUMP_ROLE_ARN:-}" ]; then
-  echo "🔐 assuming jump role ${JUMP_ROLE_ARN}"
-  CREDS_JSON=$(aws sts assume-role \
-    --role-arn "$JUMP_ROLE_ARN" \
-    --role-session-name "mars-jump-session" \
-    --output json)
-
-  AWS_ACCESS_KEY_ID=$(echo "$CREDS_JSON" | jq -r .Credentials.AccessKeyId)
-  AWS_SECRET_ACCESS_KEY=$(echo "$CREDS_JSON" | jq -r .Credentials.SecretAccessKey)
-  AWS_SESSION_TOKEN=$(echo "$CREDS_JSON" | jq -r .Credentials.SessionToken)
-  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
-  echo "✅ Now running Terraform under assumed credentials"
-fi
-
-# now hand off to the real Mars runner
+# Hand off to the real Mars runner.
+# exec replaces this process, so the trap won't fire — the Mars container
+# handles its own cleanup on exit (same as prior behavior).
 exec /opt/mars/run.sh "$@"


### PR DESCRIPTION
## Summary

- Consolidates dummy GCP credential creation and AWS jump role assumption from `tf/run-with-creds.sh` into reusable helpers in `shell_utils.sh` (`_setupDummyGCPCredentials`, `_cleanupDummyGCPCredentials`, `assumeJumpRole`)
- Adds `setupCloudEnv`/`cleanupCloudEnv` calls to `tf/drift-refresh.sh`, `tf/apply-plan.sh`, and `tf/apply-with-outputs.sh` so they no longer bypass credential setup
- Refactors `tf/run-with-creds.sh` from 66 lines of inline logic down to 18 lines using the shared helpers

Closes #34

## Test plan

- [x] All 30 tests in `tests/test-apply-scripts.sh` pass
- [x] `bash -n` syntax check passes on all modified scripts
- [x] `shellcheck -x -S warning` passes on all modified scripts
- [ ] CI `shell-lint` and `terraform-validate` jobs pass
- [ ] GCP flow unchanged — `setupCloudEnv` GCP case still calls `setupGCPCredentials` with real credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)