### PR TITLE
feat: export terraform JSON plan to outputs directory

### DIFF
--- a/tf/drift-refresh.sh
+++ b/tf/drift-refresh.sh
@@ -38,5 +38,10 @@ trap 'cleanupCloudEnv' EXIT
 terraform init -input=false
 terraform plan -refresh-only -out=refresh.tfplan -input=false
 
+# Export JSON plan for structured analysis
+mkdir -p "$MARS_PROJECT_ROOT/outputs"
+terraform show -json refresh.tfplan > "$MARS_PROJECT_ROOT/outputs/tfplan.json"
+echo "Plan JSON written to $MARS_PROJECT_ROOT/outputs/tfplan.json"
+
 # Check for drift (always fails on drift — no --ignore-drift)
 bash "$SCRIPT_DIR/drift-check.sh" refresh.tfplan

--- a/tf/plan.sh
+++ b/tf/plan.sh
@@ -9,3 +9,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 tfInit
 tfPlan
+
+# Export JSON plan for structured analysis (best-effort)
+planfile=$(find . -maxdepth 1 -name '*.tfplan' -print -quit 2>/dev/null)
+if [[ -n "$planfile" ]]; then
+  mkdir -p "$MARS_PROJECT_ROOT/outputs"
+  terraform show -json "$planfile" > "$MARS_PROJECT_ROOT/outputs/tfplan.json"
+  echo "Plan JSON written to $MARS_PROJECT_ROOT/outputs/tfplan.json"
+fi


### PR DESCRIPTION
## Summary

- Export `.tfplan` as JSON to `$MARS_PROJECT_ROOT/outputs/tfplan.json` via `terraform show -json` in both `tf/plan.sh` and `tf/drift-refresh.sh`
- `tf/plan.sh`: best-effort export — only runs when a `.tfplan` binary exists (requires caller to pass `-out=<id>.tfplan` via `TF_CLI_ARGS_plan`)
- `tf/drift-refresh.sh`: unconditional export of `refresh.tfplan` before `drift-check.sh` runs, so JSON is available even when drift causes exit code 2

Closes #41

## Test plan

- [x] `bash -n tf/plan.sh` — syntax valid
- [x] `bash -n tf/drift-refresh.sh` — syntax valid
- [x] `shellcheck tf/plan.sh tf/drift-refresh.sh` — no new warnings (only pre-existing SC1091 info about sourced files)
- [ ] Run `cd tf/cloud-provision && TF_CLI_ARGS_plan="-out=cloud-provision.tfplan" bash ../plan.sh` and verify `outputs/tfplan.json` is created
- [ ] Run `bash tf/drift-refresh.sh cloud-provision` and verify `outputs/tfplan.json` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)