### PR TITLE
feat: log template version at script startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 secrets/
 .tmp/
+.template_version

--- a/prepare-custom-stack.sh
+++ b/prepare-custom-stack.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shell_utils provides: getTfVar, mustGetTfVar, log helpers, etc.
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
+logTemplateVersion
 
 log() { echo "[prepare-custom-stack] $*" >&2; }
 

--- a/run-ansible.sh
+++ b/run-ansible.sh
@@ -12,6 +12,10 @@ export VERBOSITY=$4
 echo "whoami: $(whoami)"
 echo "pwd: $(pwd)"
 echo "date: $(date)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MARS_PROJECT_ROOT:=$SCRIPT_DIR}"
+. "$MARS_PROJECT_ROOT/shell_utils.sh"
+logTemplateVersion
 echo "docker version"
 docker --version
 

--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -440,3 +440,14 @@ cleanupCloudEnv() {
       ;;
   esac
 }
+
+# logTemplateVersion logs the infrastructure template version.
+# The .template_version file is written by Oracle during template refresh.
+logTemplateVersion() {
+  local version_file="${MARS_PROJECT_ROOT:-.}/.template_version"
+  local version=""
+  if [[ -f "$version_file" ]]; then
+    version="$(tr -d '[:space:]' < "$version_file")"
+  fi
+  echo "template_version=${version:-unknown}"
+}

--- a/tests/test-template-version.sh
+++ b/tests/test-template-version.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for logTemplateVersion() in shell_utils.sh.
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+WORKDIR="$(mktemp -d)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# --- Build a minimal project tree ---
+PROJECT="$WORKDIR/project"
+mkdir -p "$PROJECT/tf/auto-vars"
+mkdir -p "$PROJECT/ansible/inventories/default/group_vars/all"
+
+cat > "$PROJECT/ansible/inventories/default/group_vars/all/env.yaml" <<'EOF'
+environment: test
+EOF
+
+echo '{}' > "$PROJECT/tf/auto-vars/common.auto.tfvars.json"
+
+# Copy shell_utils.sh
+cp "$REPO_ROOT/shell_utils.sh" "$PROJECT/shell_utils.sh"
+
+# Helper: source shell_utils and call logTemplateVersion in the project context
+run_log_version() {
+  (
+    export MARS_PROJECT_ROOT="$PROJECT"
+    # shellcheck disable=SC1091
+    . "$PROJECT/shell_utils.sh"
+    logTemplateVersion
+  )
+}
+
+# ============================================================
+# Test 1: No .template_version file → outputs "unknown"
+# ============================================================
+echo "Test 1: Missing .template_version file..."
+
+rm -f "$PROJECT/.template_version"
+output="$(run_log_version)"
+
+if [[ "$output" == "template_version=unknown" ]]; then
+  pass "missing file: outputs template_version=unknown"
+else
+  fail "missing file: expected 'template_version=unknown', got '$output'"
+fi
+
+# ============================================================
+# Test 2: .template_version with a normal value
+# ============================================================
+echo "Test 2: Normal version string..."
+
+echo "abc123def" > "$PROJECT/.template_version"
+output="$(run_log_version)"
+
+if [[ "$output" == "template_version=abc123def" ]]; then
+  pass "normal value: outputs correct version"
+else
+  fail "normal value: expected 'template_version=abc123def', got '$output'"
+fi
+
+# ============================================================
+# Test 3: Whitespace and newlines are stripped
+# ============================================================
+echo "Test 3: Whitespace stripping..."
+
+printf "  v1.2.3  \n\n" > "$PROJECT/.template_version"
+output="$(run_log_version)"
+
+if [[ "$output" == "template_version=v1.2.3" ]]; then
+  pass "whitespace: stripped correctly"
+else
+  fail "whitespace: expected 'template_version=v1.2.3', got '$output'"
+fi
+
+# ============================================================
+# Test 4: Empty file → outputs "unknown"
+# ============================================================
+echo "Test 4: Empty .template_version file..."
+
+: > "$PROJECT/.template_version"
+output="$(run_log_version)"
+
+if [[ "$output" == "template_version=unknown" ]]; then
+  pass "empty file: outputs template_version=unknown"
+else
+  fail "empty file: expected 'template_version=unknown', got '$output'"
+fi
+
+# ============================================================
+# Test 5: File with only whitespace → outputs "unknown"
+# ============================================================
+echo "Test 5: Whitespace-only .template_version file..."
+
+printf "   \n  \n" > "$PROJECT/.template_version"
+output="$(run_log_version)"
+
+if [[ "$output" == "template_version=unknown" ]]; then
+  pass "whitespace-only: outputs template_version=unknown"
+else
+  fail "whitespace-only: expected 'template_version=unknown', got '$output'"
+fi
+
+# --- Summary ---
+echo ""
+echo "================================"
+echo "  $PASS passed, $FAIL failed"
+echo "================================"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tf/apply-plan.sh
+++ b/tf/apply-plan.sh
@@ -53,6 +53,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export MARS_PROJECT_ROOT
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
+logTemplateVersion
 
 # Source utils.sh (expects $1 = workspace/lifecycle)
 set -- "$lifecycle"

--- a/tf/apply-with-outputs.sh
+++ b/tf/apply-with-outputs.sh
@@ -43,6 +43,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${MARS_PROJECT_ROOT:=$(cd "$SCRIPT_DIR/.." && pwd)}"
 export MARS_PROJECT_ROOT
 
+. "$MARS_PROJECT_ROOT/shell_utils.sh"
+logTemplateVersion
+
 captureOutputs() {
   mkdir -p "$MARS_PROJECT_ROOT/outputs"
   terraform output -json > "$MARS_PROJECT_ROOT/outputs/outputs.json"

--- a/tf/apply.sh
+++ b/tf/apply.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 . ./utils.sh
+logTemplateVersion
 
 gitMergeInfraMain
 tfInit

--- a/tf/destroy.sh
+++ b/tf/destroy.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 . ./utils.sh
+logTemplateVersion
 
 tfInit
 tfDestroy

--- a/tf/drift-check.sh
+++ b/tf/drift-check.sh
@@ -50,6 +50,7 @@ fi
 # Resolve project root for output path
 : "${MARS_PROJECT_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 export MARS_PROJECT_ROOT
+echo "template_version=$(cat "$MARS_PROJECT_ROOT/.template_version" 2>/dev/null | tr -d '[:space:]')"
 
 OUTPUTS_DIR="$MARS_PROJECT_ROOT/outputs"
 

--- a/tf/drift-refresh.sh
+++ b/tf/drift-refresh.sh
@@ -26,6 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export MARS_PROJECT_ROOT
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
+logTemplateVersion
 
 # Source utils.sh (expects $1 = workspace/lifecycle)
 set -- "$lifecycle"

--- a/tf/plan-all.sh
+++ b/tf/plan-all.sh
@@ -22,6 +22,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${MARS_PROJECT_ROOT:=$(cd "$SCRIPT_DIR/.." && pwd)}"
 export MARS_PROJECT_ROOT
 
+. "$MARS_PROJECT_ROOT/shell_utils.sh"
+logTemplateVersion
+
 STAGES="${PLAN_STAGES:-cloud-provision custom-stack-provision}"
 OUTPUTS_DIR="$MARS_PROJECT_ROOT/outputs"
 mkdir -p "$OUTPUTS_DIR"

--- a/tf/plan.sh
+++ b/tf/plan.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 . ./utils.sh
+logTemplateVersion
 
 tfInit
 tfPlan


### PR DESCRIPTION
## Summary
- Add `logTemplateVersion()` to `shell_utils.sh` that reads `.template_version` (written by Oracle during template refresh) and prints `template_version=<value>` at startup
- All entry-point scripts (`plan.sh`, `apply.sh`, `destroy.sh`, `apply-plan.sh`, `drift-refresh.sh`, `prepare-custom-stack.sh`, `plan-all.sh`, `apply-with-outputs.sh`, `run-ansible.sh`) now call `logTemplateVersion` after sourcing
- `drift-check.sh` uses an inline echo (self-contained by design)
- `.template_version` added to `.gitignore` (runtime artifact)

## Test plan
- [x] New test: `tests/test-template-version.sh` — 5 cases (missing file, normal value, whitespace stripping, empty file, whitespace-only file)
- [x] Existing test: `tests/test-plan-all.sh` — 31 tests pass (no regression)
- [x] `bash -n` syntax check on all 12 modified files
- [ ] Manual: `echo "abc123" > .template_version && bash tf/plan.sh` prints `template_version=abc123`

Closes #46

---
*Local tests passed. Security review completed.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>