### PR TITLE
fix: read template version from TF vars + handle JSON null

### DIFF
--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -56,7 +56,7 @@ getTfVar() {
     [[ -e "$file" ]] || continue
 
     val=$(jq -r --arg k "$key" 'if has($k) then .[$k] else empty end' "$file" 2>/dev/null || echo "")
-    if [[ -n "$val" ]]; then
+    if [[ -n "$val" && "$val" != "null" ]]; then
       result="$val"
       break
     fi

--- a/tests/test-template-version.sh
+++ b/tests/test-template-version.sh
@@ -76,17 +76,19 @@ else
 fi
 
 # ============================================================
-# Test 3: template_ref with a tag value
+# Test 3: template_ref set to JSON null → outputs "unknown"
 # ============================================================
-echo "Test 3: Tag version string..."
+echo "Test 3: JSON null template_ref value..."
 
-set_template_ref "v1.2.3"
+cat > "$PROJECT/tf/auto-vars/common.auto.tfvars.json" <<'EOF'
+{"template_ref": null}
+EOF
 output="$(run_log_version)"
 
-if [[ "$output" == "template_version=v1.2.3" ]]; then
-  pass "tag value: outputs correct version"
+if [[ "$output" == "template_version=unknown" ]]; then
+  pass "null value: outputs template_version=unknown"
 else
-  fail "tag value: expected 'template_version=v1.2.3', got '$output'"
+  fail "null value: expected 'template_version=unknown', got '$output'"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary
- `logTemplateVersion()` now reads `template_ref` from TF auto-vars via `getTfVar` instead of the never-written `.template_version` file
- `getTfVar` now treats JSON `null` values as empty, preventing the literal string `"null"` from leaking to callers
- Tests updated to cover: missing key, normal value, JSON null, and empty string

Fixes #49

## Test plan
- [x] `bash tests/test-template-version.sh` — 4/4 pass
- [x] `bash -n shell_utils.sh` — syntax valid

---
*Local tests passed. Security review completed (low risk). QA professor review pending.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>