### PR TITLE
fix: support commit SHA refs in prepare-custom-stack.sh

### DIFF
--- a/prepare-custom-stack.sh
+++ b/prepare-custom-stack.sh
@@ -172,6 +172,9 @@ fi
 
 git config --global advice.detachedHead false || true
 
+# Detect 40-char hex commit SHAs (git clone --branch doesn't support them)
+is_commit_sha() { [[ "$1" =~ ^[0-9a-fA-F]{40}$ ]]; }
+
 git_clone_with_token() {
   local url="$1" ref="$2" dest="$3"
   if [[ -z "${GITHUB_TOKEN:-}" ]]; then
@@ -182,12 +185,22 @@ git_clone_with_token() {
   if [[ "$token_url" =~ ^https:// ]]; then
     token_url="${url/https:\/\//https:\/\/${GITHUB_TOKEN}@}"
   fi
-  git clone --depth 1 --no-tags --branch "$ref" "$token_url" "$dest"
+  if is_commit_sha "$ref"; then
+    git clone --no-tags "$token_url" "$dest"
+    git -C "$dest" checkout "$ref"
+  else
+    git clone --depth 1 --no-tags --branch "$ref" "$token_url" "$dest"
+  fi
 }
 
 git_clone_with_ssh() {
   local url="$1" ref="$2" dest="$3"
-  GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no' git clone --depth 1 --no-tags --branch "$ref" "$url" "$dest"
+  if is_commit_sha "$ref"; then
+    GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no' git clone --no-tags "$url" "$dest"
+    git -C "$dest" checkout "$ref"
+  else
+    GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no' git clone --depth 1 --no-tags --branch "$ref" "$url" "$dest"
+  fi
 }
 
 tmp_dir="$(mktemp -d)"

--- a/tests/test-prepare-custom-stack.sh
+++ b/tests/test-prepare-custom-stack.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 #  11. Re-deploy: no-op when .git/ already exists
 #  12. Re-deploy: no-op when repo_clone_ssh_url is empty
 #  13. Re-deploy: graceful degradation when clone fails (nonexistent repo)
+#  14. Repo mode with commit SHA ref (token auth)
+#  15. Repo mode with commit SHA ref (SSH auth)
 # Note: Collaborator invites are now handled declaratively via Terraform
 # (github_repository_collaborator resource in tf/cloud-provision/repo.tf).
 
@@ -517,6 +519,88 @@ if echo "$clone_fail_output" | grep -q "WARNING: failed to clone infra repo"; th
   pass "re-deploy: warning logged when clone fails"
 else
   fail "re-deploy: expected warning log not found in output"
+fi
+
+# --- Test 14: Repo mode with commit SHA ref (token auth) ---
+echo ""
+echo "Test 14: Repo mode with commit SHA ref (token auth)..."
+
+# Get the SHA of the commit in the bare repo we already created
+SHA_REF="$(git -C "$REPO_BARE" rev-parse HEAD)"
+
+# Reset the project target directory for this test
+rm -rf "$TARGET"
+mkdir -p "$TARGET"
+echo "existing-backend" > "$TARGET/backend.tf"
+echo "existing-providers" > "$TARGET/providers.tf"
+echo "old-version" > "$TARGET/.terraform-version"
+
+(
+  cd "$PROJECT"
+  export MARS_PROJECT_ROOT="$PROJECT"
+  export CUSTOM_ARCHIVE_TGZ=""
+  export CUSTOM_REPO_URL="file://$REPO_BARE"
+  export CUSTOM_REF="$SHA_REF"
+  export CUSTOM_AUTH="token"
+  export GITHUB_TOKEN="unused-local-clone"
+  bash prepare-custom-stack.sh
+) 2>&1 | sed 's/^/  | /'
+
+if [[ -f "$TARGET/main.tf" ]] && [[ "$(cat "$TARGET/main.tf")" == "repo-main" ]]; then
+  pass "SHA ref (token): main.tf checked out from commit SHA"
+else
+  fail "SHA ref (token): main.tf not found or wrong content"
+fi
+
+if [[ -f "$TARGET/.terraform-version" ]] && [[ "$(cat "$TARGET/.terraform-version")" == "1.9.0" ]]; then
+  pass "SHA ref (token): .terraform-version correct"
+else
+  fail "SHA ref (token): .terraform-version missing or wrong"
+fi
+
+if [[ -f "$TARGET/backend.tf" ]] && [[ "$(cat "$TARGET/backend.tf")" == "existing-backend" ]]; then
+  pass "SHA ref (token): preserved files intact"
+else
+  fail "SHA ref (token): preserved files not intact"
+fi
+
+# --- Test 15: Repo mode with commit SHA ref (SSH auth) ---
+echo ""
+echo "Test 15: Repo mode with commit SHA ref (SSH auth)..."
+
+# Reset the project target directory for this test
+rm -rf "$TARGET"
+mkdir -p "$TARGET"
+echo "existing-backend" > "$TARGET/backend.tf"
+echo "existing-providers" > "$TARGET/providers.tf"
+echo "old-version" > "$TARGET/.terraform-version"
+
+(
+  cd "$PROJECT"
+  export MARS_PROJECT_ROOT="$PROJECT"
+  export CUSTOM_ARCHIVE_TGZ=""
+  export CUSTOM_REPO_URL="file://$REPO_BARE"
+  export CUSTOM_REF="$SHA_REF"
+  export CUSTOM_AUTH="ssh"
+  bash prepare-custom-stack.sh
+) 2>&1 | sed 's/^/  | /'
+
+if [[ -f "$TARGET/main.tf" ]] && [[ "$(cat "$TARGET/main.tf")" == "repo-main" ]]; then
+  pass "SHA ref (ssh): main.tf checked out from commit SHA"
+else
+  fail "SHA ref (ssh): main.tf not found or wrong content"
+fi
+
+if [[ -f "$TARGET/.terraform-version" ]] && [[ "$(cat "$TARGET/.terraform-version")" == "1.9.0" ]]; then
+  pass "SHA ref (ssh): .terraform-version correct"
+else
+  fail "SHA ref (ssh): .terraform-version missing or wrong"
+fi
+
+if [[ -f "$TARGET/backend.tf" ]] && [[ "$(cat "$TARGET/backend.tf")" == "existing-backend" ]]; then
+  pass "SHA ref (ssh): preserved files intact"
+else
+  fail "SHA ref (ssh): preserved files not intact"
 fi
 
 # --- Summary ---


### PR DESCRIPTION
## Summary

- `git clone --branch` only accepts branch/tag names, not 40-char commit SHAs. When `SandboxTemplateRef` is pinned to a commit SHA, the clone fails with a cryptic error.
- Adds `is_commit_sha()` helper that detects 40-char hex strings, and updates both `git_clone_with_token()` and `git_clone_with_ssh()` to do a full clone + checkout when the ref is a SHA (instead of using `--branch`).
- Adds tests 14-15 covering SHA ref cloning via both token and SSH auth modes.

Closes #51

## Test plan

- [x] All 15 existing + new tests pass (33 assertions, 0 failures)
- [x] Tests 14-15 create a local bare repo, resolve its HEAD SHA, pass it as `CUSTOM_REF`, and verify correct checkout for both `token` and `ssh` auth modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)