### PR TITLE
fix: skip remote state on new projects to unblock plan-all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 secrets/
 .tmp/
 .template_version
+tf/auto-vars/skip_remote_state.auto.tfvars.json

--- a/tests/test-plan-all.sh
+++ b/tests/test-plan-all.sh
@@ -474,6 +474,74 @@ else
   fail "destroy: read actions should not be counted"
 fi
 
+# ============================================================
+# Test 7: New project (no prior_state) — skip_remote_state auto-detected
+# ============================================================
+echo ""
+echo "Test 7: New project skip_remote_state detection..."
+
+# cloud-provision plan with no prior_state (new project)
+echo '{"resource_changes": [], "prior_state": {"values": {"root_module": {"resources": []}}}}' > "$STAGE_PLANS_DIR/cloud-provision.json"
+echo '{"resource_changes": []}' > "$STAGE_PLANS_DIR/custom-stack-provision.json"
+
+set +e
+output="$(run_plan_all 2>&1)"
+exit_code=$?
+set -e
+
+if echo "$output" | grep -q "skip_remote_state=true"; then
+  pass "new-project: skip_remote_state=true detected"
+else
+  fail "new-project: should detect skip_remote_state=true. Output: $output"
+fi
+
+# The temp file should be cleaned up by the EXIT trap
+if [[ ! -f "$PROJECT/tf/auto-vars/skip_remote_state.auto.tfvars.json" ]]; then
+  pass "new-project: temp auto-var cleaned up"
+else
+  fail "new-project: temp auto-var should be cleaned up"
+fi
+
+# ============================================================
+# Test 8: Existing project (has prior_state resources) — skip NOT triggered
+# ============================================================
+echo ""
+echo "Test 8: Existing project — skip_remote_state NOT triggered..."
+
+# cloud-provision plan with prior_state containing resources (existing project)
+cat > "$STAGE_PLANS_DIR/cloud-provision.json" <<'EOF'
+{
+  "resource_changes": [],
+  "prior_state": {
+    "values": {
+      "root_module": {
+        "resources": [
+          {"address": "aws_s3_bucket.state", "type": "aws_s3_bucket", "values": {}}
+        ]
+      }
+    }
+  }
+}
+EOF
+echo '{"resource_changes": []}' > "$STAGE_PLANS_DIR/custom-stack-provision.json"
+
+set +e
+output="$(run_plan_all 2>&1)"
+exit_code=$?
+set -e
+
+if echo "$output" | grep -q "skip_remote_state=true"; then
+  fail "existing-project: should NOT detect skip_remote_state. Output: $output"
+else
+  pass "existing-project: skip_remote_state not triggered"
+fi
+
+if [[ ! -f "$PROJECT/tf/auto-vars/skip_remote_state.auto.tfvars.json" ]]; then
+  pass "existing-project: no temp auto-var created"
+else
+  fail "existing-project: temp auto-var should not exist"
+fi
+
 # --- Summary ---
 echo ""
 echo "================================"

--- a/tf/custom-stack-provision/__customer_cloud_provision_state.tf
+++ b/tf/custom-stack-provision/__customer_cloud_provision_state.tf
@@ -1,6 +1,7 @@
 # AWS: Read remote state from S3 (only used for AWS deployments)
+# Skipped when skip_remote_state=true (e.g. plan-only on new projects with no state yet)
 data "terraform_remote_state" "cloud_provision" {
-  count   = var.cloud_provider == "aws" ? 1 : 0
+  count   = var.cloud_provider == "aws" && !var.skip_remote_state ? 1 : 0
   backend = "s3"
 
   config = {
@@ -13,11 +14,11 @@ data "terraform_remote_state" "cloud_provision" {
 }
 
 locals {
-  # AWS: Get role ARN from remote state
-  terraform_role_arn = var.cloud_provider == "aws" ? data.terraform_remote_state.cloud_provision[0].outputs.terraform_role : ""
+  # AWS: Get role ARN from remote state, fall back to var when skipped
+  terraform_role_arn = var.cloud_provider == "aws" && !var.skip_remote_state ? data.terraform_remote_state.cloud_provision[0].outputs.terraform_role : var.terraform_sa_role
 
   # Domain is available in both clouds (passed via tfvars)
-  domain = var.cloud_provider == "aws" ? data.terraform_remote_state.cloud_provision[0].outputs.domain : var.domain
+  domain = var.cloud_provider == "aws" && !var.skip_remote_state ? data.terraform_remote_state.cloud_provision[0].outputs.domain : var.domain
 }
 
 # Domain variable for GCP (AWS gets it from remote state)

--- a/tf/custom-stack-provision/__customer_state_inputs.tf
+++ b/tf/custom-stack-provision/__customer_state_inputs.tf
@@ -1,4 +1,10 @@
 # Inputs needed to read the cloud-provision remote state and choose the role/region
+variable "skip_remote_state" {
+  description = "Skip reading remote state from prior stages (for plan-only on new projects)"
+  type        = bool
+  default     = false
+}
+
 variable "short_project_id" { type = string }
 variable "project_id" {
   description = "Full Luther project ID"

--- a/tf/custom-stack-provision/providers.tf
+++ b/tf/custom-stack-provision/providers.tf
@@ -19,7 +19,7 @@ terraform {
 provider "aws" {
   region = var.cloud_provider == "aws" ? var.aws_region : "us-west-2"
   assume_role {
-    role_arn    = var.cloud_provider == "aws" ? local.terraform_role_arn : null
+    role_arn    = var.cloud_provider == "aws" && local.terraform_role_arn != "" ? local.terraform_role_arn : null
     external_id = var.cloud_provider == "aws" && var.aws_external_id != "" ? var.aws_external_id : null
   }
 }
@@ -29,7 +29,7 @@ provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
   assume_role {
-    role_arn    = var.cloud_provider == "aws" ? local.terraform_role_arn : null
+    role_arn    = var.cloud_provider == "aws" && local.terraform_role_arn != "" ? local.terraform_role_arn : null
     external_id = var.cloud_provider == "aws" && var.aws_external_id != "" ? var.aws_external_id : null
   }
 }

--- a/tf/plan-all.sh
+++ b/tf/plan-all.sh
@@ -34,7 +34,12 @@ had_changes=false
 
 # Per-stage results stored as temp files for aggregation
 results_dir="$(mktemp -d)"
-trap 'rm -rf "$results_dir"' EXIT
+SKIP_REMOTE_STATE_FILE="$SCRIPT_DIR/auto-vars/skip_remote_state.auto.tfvars.json"
+cleanup_plan_all() {
+  rm -rf "$results_dir"
+  rm -f "$SKIP_REMOTE_STATE_FILE"
+}
+trap cleanup_plan_all EXIT
 
 for stage in $STAGES; do
   echo ""
@@ -53,6 +58,16 @@ for stage in $STAGES; do
     had_error=true
     echo '{"error": true}' > "$results_dir/$stage.json"
     continue
+  fi
+
+  # Auto-detect new project: if cloud-provision has no prior state, inject
+  # skip_remote_state=true so downstream stages don't try to read it.
+  if [[ "$stage" == "cloud-provision" && -f "$plan_file" ]]; then
+    prior_resource_count="$(jq '[.prior_state.values.root_module.resources // [] | .[]] | length' "$plan_file" 2>/dev/null || echo "0")"
+    if [[ "$prior_resource_count" -eq 0 ]]; then
+      echo "INFO: New project detected (no prior state in cloud-provision). Setting skip_remote_state=true."
+      echo '{"skip_remote_state": true}' > "$SKIP_REMOTE_STATE_FILE"
+    fi
   fi
 
   if [[ ! -f "$plan_file" ]]; then


### PR DESCRIPTION
## Summary
- When `plan-all.sh` runs on a brand-new project, `custom-stack-provision` fails because `terraform_remote_state` tries to read cloud-provision's S3 state that doesn't exist yet
- Adds auto-detection: if cloud-provision's plan JSON shows no `prior_state` resources, a temp `skip_remote_state.auto.tfvars.json` is written so custom-stack-provision skips the data source and falls back to variable defaults
- AWS provider `role_arn` now handles empty strings (returns `null` instead of `""` which errors on provider >= 6.0)

Closes luthersystems/reliable#597

## Changes
- `tf/custom-stack-provision/__customer_state_inputs.tf` — new `skip_remote_state` variable
- `tf/custom-stack-provision/__customer_cloud_provision_state.tf` — conditional remote state + fallback locals
- `tf/custom-stack-provision/providers.tf` — handle empty `role_arn` in both AWS provider blocks
- `tf/plan-all.sh` — auto-detect new project via `prior_state`, write/cleanup temp auto-var
- `.gitignore` — exclude temp auto-var file
- `tests/test-plan-all.sh` — 2 new test cases (tests 7-8)

## Test plan
- [x] `bash tests/test-plan-all.sh` — all 35 tests pass (including 2 new)
- [x] `bash -n tf/plan-all.sh` — syntax valid
- [x] Security review — no concerns (infra-only, no user input, temp file cleaned on EXIT)

---
*Local tests passed. Security review completed.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>