### PR TITLE
fix: write empty drift.json stub during apply to suppress Argo warning

### DIFF
--- a/tf/apply-plan.sh
+++ b/tf/apply-plan.sh
@@ -92,3 +92,10 @@ captureOutputs() {
 }
 
 captureOutputs
+
+# Write empty drift.json stub if not already present so Argo doesn't
+# warn about a missing optional artifact.
+if [ ! -f "$MARS_PROJECT_ROOT/outputs/drift.json" ]; then
+  mkdir -p "$MARS_PROJECT_ROOT/outputs"
+  echo '{}' > "$MARS_PROJECT_ROOT/outputs/drift.json"
+fi

--- a/tf/apply-with-outputs.sh
+++ b/tf/apply-with-outputs.sh
@@ -90,3 +90,10 @@ else
 
   captureOutputs
 fi
+
+# Write empty drift.json stub if not already present so Argo doesn't
+# warn about a missing optional artifact.
+if [ ! -f "$MARS_PROJECT_ROOT/outputs/drift.json" ]; then
+  mkdir -p "$MARS_PROJECT_ROOT/outputs"
+  echo '{}' > "$MARS_PROJECT_ROOT/outputs/drift.json"
+fi


### PR DESCRIPTION
## Summary
- Writes an empty `{}` to `drift.json` at the end of `apply-with-outputs.sh` and `apply-plan.sh` when no drift was detected
- Suppresses Argo's warning about a missing optional artifact without changing any behavior
- An empty `{}` is distinguishable from real drift output

Closes #57

## Test plan
- [ ] Run apply without `--check-drift` — verify `drift.json` is created with `{}`
- [ ] Run apply with `--check-drift` and no drift — verify `drift.json` is created with `{}`
- [ ] Run apply with `--check-drift` and drift detected — verify existing `drift.json` is preserved
- [ ] Verify Argo no longer logs the missing artifact warning

---
*Security review: no sensitive changes (writes static `{}` to output dir). No test files modified.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)