### PR TITLE
fix: require external id on account setup admin role

### DIFF
--- a/tf/account-setup/main.tf
+++ b/tf/account-setup/main.tf
@@ -23,6 +23,15 @@ data "aws_iam_policy_document" "admin_assume_policy" {
     }
 
     actions = ["sts:AssumeRole"]
+
+    dynamic "condition" {
+      for_each = var.aws_external_id != "" ? [var.aws_external_id] : []
+      content {
+        test     = "StringEquals"
+        variable = "sts:ExternalId"
+        values   = [condition.value]
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- require `sts:ExternalId` on the AWS account-setup admin role when `aws_external_id` is configured
- preserve backward compatibility by omitting the trust-policy condition when `aws_external_id` is empty
- align the durable admin role with the existing AWS role-arn flow's confused-deputy protection

## Testing
- `terraform -chdir=tf/account-setup fmt`
- `terraform -chdir=tf/account-setup init -backend=false`
- `terraform -chdir=tf/account-setup validate` *(fails locally due to cached `hashicorp/aws` provider plugin instantiation error on this machine)*

Closes #59.
