### PR TITLE
fix: harden cloud-provision bootstrap outputs

### DIFF
--- a/tf/account-provision/main.tf
+++ b/tf/account-provision/main.tf
@@ -23,7 +23,7 @@ locals {
 }
 
 module "luthername_org" {
-  source = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.1"
+  source = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.2"
 
   luther_project = var.short_project_id
   aws_region     = var.aws_region

--- a/tf/account-provision/version.tf
+++ b/tf/account-provision/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/tf/account-setup/main.tf
+++ b/tf/account-setup/main.tf
@@ -1,5 +1,5 @@
 module "luthername_admin" {
-  source = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.1"
+  source = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.2"
 
   luther_project = var.short_project_id
   aws_region     = var.aws_region

--- a/tf/account-setup/version.tf
+++ b/tf/account-setup/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/tf/cloud-provision/inspector.tf
+++ b/tf/cloud-provision/inspector.tf
@@ -13,6 +13,11 @@ locals {
 
   # Extract deployment SA email from credentials for token creator binding
   gcp_deployment_sa_email = local.is_gcp ? jsondecode(base64decode(var.gcp_credentials_b64)).client_email : ""
+
+  inspector_role_arn      = try(aws_iam_role.insideout_inspector[0].arn, "")
+  inspector_role_name_out = try(aws_iam_role.insideout_inspector[0].name, "")
+  gcp_inspector_sa_email  = try(google_service_account.insideout_inspector[0].email, "")
+  gcp_inspector_sa_id_out = try(google_service_account.insideout_inspector[0].account_id, "")
 }
 
 data "aws_iam_policy_document" "inspector_assume" {
@@ -125,22 +130,21 @@ resource "google_service_account_iam_member" "inspector_token_creator" {
 
 output "inspector_role_arn" {
   description = "ARN of the InsideOut inspector role (AWS only)"
-  value       = local.is_aws ? aws_iam_role.insideout_inspector[0].arn : ""
+  value       = local.is_aws ? local.inspector_role_arn : ""
 }
 
 output "inspector_role_name" {
   description = "Name of the InsideOut inspector role (AWS only)"
-  value       = local.is_aws ? aws_iam_role.insideout_inspector[0].name : ""
+  value       = local.is_aws ? local.inspector_role_name_out : ""
 }
 
 output "gcp_inspector_sa_email" {
   description = "Email of the GCP inspector service account (GCP only)"
-  value       = local.is_gcp ? google_service_account.insideout_inspector[0].email : ""
+  value       = local.is_gcp ? local.gcp_inspector_sa_email : ""
 }
 
 output "gcp_inspector_sa_id" {
   description = "ID of the GCP inspector service account (GCP only)"
-  value       = local.is_gcp ? google_service_account.insideout_inspector[0].account_id : ""
+  value       = local.is_gcp ? local.gcp_inspector_sa_id_out : ""
 }
-
 

--- a/tf/cloud-provision/main.tf
+++ b/tf/cloud-provision/main.tf
@@ -14,7 +14,7 @@ locals {
 
 module "bootstrap" {
   count  = local.is_aws ? 1 : 0
-  source = "github.com/luthersystems/tf-modules.git//aws-platform-ui-bootstrap?ref=v55.15.1"
+  source = "github.com/luthersystems/tf-modules.git//aws-platform-ui-bootstrap?ref=v55.15.2"
 
   admin_role_name     = local.admin_role_name
   create_dns          = var.create_dns

--- a/tf/cloud-provision/template.tf
+++ b/tf/cloud-provision/template.tf
@@ -7,11 +7,11 @@ locals {
   state_workspace_k8s = "k8s"
 
   # AWS-specific state configuration
-  state_kms_key_id = local.is_aws ? module.bootstrap[0].aws_kms_key_id : ""
+  state_kms_key_id = local.is_aws ? try(module.bootstrap[0].aws_kms_key_id, "") : ""
   state_role_arn   = local.admin_role_arn
 
   state = local.is_aws ? {
-    bucket = module.bootstrap[0].aws_s3_bucket_tfstate
+    bucket = try(module.bootstrap[0].aws_s3_bucket_tfstate, "")
     region = var.aws_region
   } : {}
 

--- a/tf/cloud-provision/versions.tf
+++ b/tf/cloud-provision/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/tf/k8s-provision/namespaces/versions.tf
+++ b/tf/k8s-provision/namespaces/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tf/k8s-provision/versions.tf
+++ b/tf/k8s-provision/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/tf/vm-provision/main.tf
+++ b/tf/vm-provision/main.tf
@@ -1,5 +1,5 @@
 module "storage" {
-  source = "github.com/luthersystems/tf-modules.git//aws-platform-ui-storage?ref=v55.15.1"
+  source = "github.com/luthersystems/tf-modules.git//aws-platform-ui-storage?ref=v55.15.2"
 
   luther_project = var.short_project_id
   luther_env     = var.luther_env
@@ -36,7 +36,7 @@ output "static_bucket_kms_key_arn" {
 }
 
 module "main" {
-  source = "github.com/luthersystems/tf-modules.git//aws-platform-ui-main?ref=v55.15.1"
+  source = "github.com/luthersystems/tf-modules.git//aws-platform-ui-main?ref=v55.15.2"
 
   luther_project           = var.short_project_id
   luther_env               = var.luther_env

--- a/tf/vm-provision/service_accounts.tf
+++ b/tf/vm-provision/service_accounts.tf
@@ -1,5 +1,5 @@
 module "connectorhub_service_account_iam_role" {
-  source = "github.com/luthersystems/tf-modules//eks-service-account-iam-role?ref=v55.15.1"
+  source = "github.com/luthersystems/tf-modules//eks-service-account-iam-role?ref=v55.15.2"
 
   luther_project = var.short_project_id
   aws_region     = var.aws_region
@@ -21,7 +21,7 @@ output "connectorhub_service_account_role_arn" {
 }
 
 module "oracle_service_account_iam_role" {
-  source = "github.com/luthersystems/tf-modules//eks-service-account-iam-role?ref=v55.15.1"
+  source = "github.com/luthersystems/tf-modules//eks-service-account-iam-role?ref=v55.15.2"
 
   luther_project = var.short_project_id
   aws_region     = var.aws_region

--- a/tf/vm-provision/versions.tf
+++ b/tf/vm-provision/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Summary
- update all pinned `tf-modules` refs from `v55.15.1` to `v55.15.2`
- guard `tf/cloud-provision` inspector and bootstrap-derived outputs against missing legacy resources
- raise the remaining Terraform `>= 1.0` floors in this repo to `>= 1.2` to match the released bootstrap module floor

## Test plan
- [x] `cd tf/cloud-provision && terraform init -backend=false`
- [x] `cd tf/cloud-provision && terraform validate`
- [ ] Run a drift/refresh plan against a legacy AWS project with missing bootstrap resources

## Related
- Closes #61
- Depends on: luthersystems/tf-modules/releases/tag/v55.15.2

---
Local validation passed. Security review: low-risk Terraform version and expression changes only; no secrets, auth flows, or runtime shell behavior changed.
