### PR TITLE
fix: remove exit code 2 from plan-all.sh to prevent Argo failure status

### DIFF
--- a/tf/plan-all.sh
+++ b/tf/plan-all.sh
@@ -12,8 +12,7 @@
 #   outputs/plan-summary.json    Aggregated change counts across all stages
 #
 # Exit codes:
-#   0 — All stages planned successfully, no changes in any stage
-#   2 — All stages planned successfully, changes exist in at least one stage
+#   0 — All stages planned successfully (changes reported in plan-summary.json)
 #   1 — At least one stage failed to plan
 
 set -euo pipefail
@@ -172,8 +171,6 @@ echo "$summary" | jq '.'
 # Exit codes
 if [[ "$had_error" == "true" ]]; then
   exit 1
-elif [[ "$had_changes" == "true" ]]; then
-  exit 2
 else
   exit 0
 fi


### PR DESCRIPTION
## Summary

- Remove exit code 2 ("changes detected") from `tf/plan-all.sh` — Argo treats any non-zero exit as a container failure, so successful plans with changes were reported as `Failed`
- The structured `plan-summary.json` already carries `has_changes: true/false`, making the exit code convention redundant
- Only exit 1 remains for actual planning errors

Closes #66

## Test plan

- [ ] Run `plan-all.sh` against a project with pending changes — confirm exit code 0 (not 2)
- [ ] Run `plan-all.sh` against a project with no changes — confirm exit code 0
- [ ] Run `plan-all.sh` with a broken stage — confirm exit code 1
- [ ] Verify `plan-summary.json` still contains correct `has_changes` values in all cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)