### PR TITLE
fix: use bootstrap_state_region for S3 state bucket in cloud-provision

### DIFF
--- a/tf/cloud-provision/template.tf
+++ b/tf/cloud-provision/template.tf
@@ -12,7 +12,7 @@ locals {
 
   state = local.is_aws ? {
     bucket = try(module.bootstrap[0].aws_s3_bucket_tfstate, "")
-    region = var.aws_region
+    region = var.bootstrap_state_region != "" ? var.bootstrap_state_region : var.aws_region
   } : {}
 
   state_backend_vm = local.is_aws ? merge(local.state, {

--- a/tf/cloud-provision/unused-vars.tf
+++ b/tf/cloud-provision/unused-vars.tf
@@ -46,11 +46,6 @@ variable "bootstrap_state_kms_key_id" {
   default = ""
 }
 
-variable "bootstrap_state_region" {
-  type    = string
-  default = ""
-}
-
 variable "eks_version" {
   type    = string
   default = ""

--- a/tf/cloud-provision/vars.tf
+++ b/tf/cloud-provision/vars.tf
@@ -82,6 +82,12 @@ variable "aws_region" {
   default     = ""
 }
 
+variable "bootstrap_state_region" {
+  description = "AWS region where the S3 state bucket lives (falls back to aws_region if empty)"
+  type        = string
+  default     = ""
+}
+
 variable "bootstrap_role" {
   description = "AWS IAM role ARN for Terraform (required for AWS deployments)"
   type        = string


### PR DESCRIPTION
## Summary

- Use `bootstrap_state_region` instead of `aws_region` for the S3 state backend region in `cloud-provision`, fixing 301 MovedPermanently errors when the state bucket lives in a different region than `aws_region`
- Falls back to `aws_region` when `bootstrap_state_region` is empty (first-time bootstrap before the Go workflow populates it)
- Moved `bootstrap_state_region` variable from `unused-vars.tf` to `vars.tf` since it's now actively used

Fixes #72

## Test plan

- [x] `terraform validate` passes
- [ ] Deploy against a project whose S3 state bucket is in a non-default region and confirm no 301 error
- [ ] First-time bootstrap (empty `bootstrap_state_region`) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)