### PR TITLE
fix: save lifecycle-specific outputs alongside outputs.json

### DIFF
--- a/tests/test-apply-scripts.sh
+++ b/tests/test-apply-scripts.sh
@@ -168,6 +168,18 @@ else
   fail "simple mode: outputs.json content wrong"
 fi
 
+if [[ -f "$PROJECT/outputs/default.json" ]]; then
+  pass "simple mode: lifecycle-specific default.json created"
+else
+  fail "simple mode: lifecycle-specific default.json not created"
+fi
+
+if jq -e '.vpc_id.value == "vpc-123"' "$PROJECT/outputs/default.json" >/dev/null 2>&1; then
+  pass "simple mode: default.json has correct content"
+else
+  fail "simple mode: default.json content wrong"
+fi
+
 # --- Test 2: Drift-check mode runs terraform directly ---
 echo ""
 echo "Test 2: Drift-check mode (no drift)..."
@@ -214,6 +226,18 @@ if jq -e '.vpc_id.value == "vpc-123"' "$PROJECT/outputs/outputs.json" >/dev/null
   pass "drift-check mode: outputs.json has correct content"
 else
   fail "drift-check mode: outputs.json content wrong"
+fi
+
+if [[ -f "$PROJECT/outputs/default.json" ]]; then
+  pass "drift-check mode: lifecycle-specific default.json created"
+else
+  fail "drift-check mode: lifecycle-specific default.json not created"
+fi
+
+if jq -e '.vpc_id.value == "vpc-123"' "$PROJECT/outputs/default.json" >/dev/null 2>&1; then
+  pass "drift-check mode: default.json has correct content"
+else
+  fail "drift-check mode: default.json content wrong"
 fi
 
 # --- Test 3: Drift-check mode + drift detected → exit 2, apply not called ---
@@ -323,6 +347,18 @@ if jq -e '.vpc_id.value == "vpc-123"' "$PROJECT/outputs/outputs.json" >/dev/null
   pass "apply-plan basic: outputs.json has correct content"
 else
   fail "apply-plan basic: outputs.json content wrong"
+fi
+
+if [[ -f "$PROJECT/outputs/default.json" ]]; then
+  pass "apply-plan basic: lifecycle-specific default.json created"
+else
+  fail "apply-plan basic: lifecycle-specific default.json not created"
+fi
+
+if jq -e '.vpc_id.value == "vpc-123"' "$PROJECT/outputs/default.json" >/dev/null 2>&1; then
+  pass "apply-plan basic: default.json has correct content"
+else
+  fail "apply-plan basic: default.json content wrong"
 fi
 
 # --- Test 5: Provider cache cleaned before init ---

--- a/tf/apply-plan.sh
+++ b/tf/apply-plan.sh
@@ -89,6 +89,8 @@ captureOutputs() {
   mkdir -p "$MARS_PROJECT_ROOT/outputs"
   terraform output -json > "$MARS_PROJECT_ROOT/outputs/outputs.json"
   echo "Outputs written to $MARS_PROJECT_ROOT/outputs/outputs.json"
+  cp "$MARS_PROJECT_ROOT/outputs/outputs.json" "$MARS_PROJECT_ROOT/outputs/${lifecycle}.json"
+  echo "Outputs also saved to $MARS_PROJECT_ROOT/outputs/${lifecycle}.json"
 }
 
 captureOutputs

--- a/tf/apply-with-outputs.sh
+++ b/tf/apply-with-outputs.sh
@@ -50,6 +50,8 @@ captureOutputs() {
   mkdir -p "$MARS_PROJECT_ROOT/outputs"
   terraform output -json > "$MARS_PROJECT_ROOT/outputs/outputs.json"
   echo "Outputs written to $MARS_PROJECT_ROOT/outputs/outputs.json"
+  cp "$MARS_PROJECT_ROOT/outputs/outputs.json" "$MARS_PROJECT_ROOT/outputs/${lifecycle}.json"
+  echo "Outputs also saved to $MARS_PROJECT_ROOT/outputs/${lifecycle}.json"
 }
 
 if [[ "$check_drift" == "true" ]]; then


### PR DESCRIPTION
## Summary

- `captureOutputs()` in both `tf/apply-with-outputs.sh` and `tf/apply-plan.sh` now copies `outputs/outputs.json` to `outputs/${lifecycle}.json` (e.g., `cloud-provision.json`)
- Fixes multi-stage workflows where each stage overwrites the single `outputs.json`, causing downstream consumers (like the Oracle's `ResolveProjectManagementAccess()`) to lose earlier stages' outputs
- Adds 6 new test assertions in `tests/test-apply-scripts.sh` verifying lifecycle-specific files are created with correct content

Closes luthersystems/ui-core#266

## Test plan

- [x] `bash tests/test-apply-scripts.sh` — 36/36 pass (6 new assertions)
- [ ] Deploy multi-stage workflow and verify `outputs/cloud-provision.json` exists alongside `outputs/outputs.json`
- [ ] Confirm Oracle `DurableReady` resolves to `true` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)