### PR TITLE
fix: use var.aws_region for project state backend region

### DIFF
--- a/tf/cloud-provision/template.tf
+++ b/tf/cloud-provision/template.tf
@@ -12,7 +12,7 @@ locals {
 
   state = local.is_aws ? {
     bucket = try(module.bootstrap[0].aws_s3_bucket_tfstate, "")
-    region = var.bootstrap_state_region != "" ? var.bootstrap_state_region : var.aws_region
+    region = var.aws_region
   } : {}
 
   state_backend_vm = local.is_aws ? merge(local.state, {


### PR DESCRIPTION
## Summary

- Fixes `template.tf` to use `var.aws_region` instead of `bootstrap_state_region` for the project state backend region
- The project's S3 state bucket is created in `var.aws_region`, so downstream stages (vm-provision, k8s-provision, custom-stack-provision) must use that region in their backend config
- `bootstrap_state_region` is the Oracle platform region (e.g. `us-west-2`), which differs from the project region when deploying to a non-default region

Fixes #82

## Test plan

- [x] `tests/test-state-region.sh` passes (2/2 checks)
- [ ] `terraform validate` on cloud-provision stage (requires credentials)
- [ ] Deploy to a non-default region and verify downstream stages initialize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)