### PR TITLE
fix: filter false-positive drift from null-vs-empty normalization

### DIFF
--- a/tests/test-drift-check.sh
+++ b/tests/test-drift-check.sh
@@ -347,6 +347,122 @@ else
   fail "no stage: drift-.json should not exist"
 fi
 
+# ============================================================
+# Test 11: All-false-positive drift (null vs empty) — exit 0, no drift.json
+# ============================================================
+echo ""
+echo "Test 11: All-false-positive drift (null vs empty equivalences)..."
+
+rm -rf "$WORKDIR/outputs"
+false_positive_plan='{"resource_drift": [
+  {
+    "address": "aws_s3_bucket.example",
+    "type": "aws_s3_bucket",
+    "change": {
+      "before": {"cors_rule": null, "grant": null, "lifecycle_rule": null, "logging": null, "replication_configuration": null, "server_side_encryption_configuration": [], "versioning": [{"enabled": false, "mfa_delete": false}], "website": null, "policy": null},
+      "after":  {"cors_rule": [],   "grant": [],   "lifecycle_rule": [],   "logging": {},   "replication_configuration": "",  "server_side_encryption_configuration": [], "versioning": [{"enabled": false, "mfa_delete": false}], "website": [],   "policy": ""}
+    }
+  }
+]}'
+result="$(run_drift_check "$false_positive_plan")"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "false-positive: exit code 0 (no real drift)"
+else
+  fail "false-positive: expected exit 0, got $exit_code"
+fi
+
+if [[ ! -f "$WORKDIR/outputs/drift.json" ]]; then
+  pass "false-positive: drift.json not created"
+else
+  fail "false-positive: drift.json should not exist for false-positive only drift"
+fi
+
+# ============================================================
+# Test 12: Mixed real + false-positive drift — exit 2, only real drift in report
+# ============================================================
+echo ""
+echo "Test 12: Mixed real and false-positive drift..."
+
+rm -rf "$WORKDIR/outputs"
+mixed_plan='{"resource_drift": [
+  {
+    "address": "aws_s3_bucket.false_positive",
+    "type": "aws_s3_bucket",
+    "change": {
+      "before": {"cors_rule": null, "tags": {"env": "prod"}},
+      "after":  {"cors_rule": [],   "tags": {"env": "prod"}}
+    }
+  },
+  {
+    "address": "aws_instance.real_drift",
+    "type": "aws_instance",
+    "change": {
+      "before": {"instance_type": "t3.micro", "tags": {"Name": "old"}},
+      "after":  {"instance_type": "t3.small", "tags": {"Name": "new"}}
+    }
+  }
+]}'
+result="$(run_drift_check "$mixed_plan")"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 2 ]]; then
+  pass "mixed: exit code 2 (real drift present)"
+else
+  fail "mixed: expected exit 2, got $exit_code"
+fi
+
+if [[ -f "$WORKDIR/outputs/drift.json" ]]; then
+  pass "mixed: drift.json created"
+else
+  fail "mixed: drift.json not created"
+fi
+
+if jq -e '.drift_count == 1' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "mixed: drift_count is 1 (false positive filtered out)"
+else
+  fail "mixed: drift_count should be 1"
+fi
+
+if jq -e '.resources[0].address == "aws_instance.real_drift"' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "mixed: only real drift resource in report"
+else
+  fail "mixed: expected aws_instance.real_drift in report"
+fi
+
+# ============================================================
+# Test 13: Nested null-vs-empty inside objects/arrays — exit 0
+# ============================================================
+echo ""
+echo "Test 13: Nested null-vs-empty inside objects and arrays..."
+
+rm -rf "$WORKDIR/outputs"
+nested_plan='{"resource_drift": [
+  {
+    "address": "aws_lb.example",
+    "type": "aws_lb",
+    "change": {
+      "before": {"access_logs": [{"bucket": "", "enabled": false, "prefix": null}], "subnet_mapping": [{"outpost_arn": null}], "tags": {}},
+      "after":  {"access_logs": [{"bucket": "", "enabled": false, "prefix": ""}],  "subnet_mapping": [{"outpost_arn": ""}],  "tags": null}
+    }
+  }
+]}'
+result="$(run_drift_check "$nested_plan")"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "nested: exit code 0 (no real drift)"
+else
+  fail "nested: expected exit 0, got $exit_code"
+fi
+
+if [[ ! -f "$WORKDIR/outputs/drift.json" ]]; then
+  pass "nested: drift.json not created"
+else
+  fail "nested: drift.json should not exist for nested false-positive drift"
+fi
+
 # --- Summary ---
 echo ""
 echo "================================"

--- a/tf/drift-check.sh
+++ b/tf/drift-check.sh
@@ -57,7 +57,37 @@ OUTPUTS_DIR="$MARS_PROJECT_ROOT/outputs"
 # Convert binary plan to JSON and check for drift
 plan_json="$(terraform show -json "$plan_file")"
 
-drift="$(echo "$plan_json" | jq '.resource_drift // []')"
+# jq function to normalize null-equivalent values so that null vs [] / {} / false / 0 / ""
+# comparisons don't produce false-positive drift.
+# shellcheck disable=SC2016
+_normalize='
+def normalize_empty:
+  if . == null then null
+  elif . == [] then null
+  elif . == {} then null
+  elif . == false then null
+  elif . == 0 then null
+  elif . == "" then null
+  elif type == "array" then map(normalize_empty)
+  elif type == "object" then with_entries(.value |= normalize_empty)
+  else .
+  end;
+'
+
+# Extract resource_drift, filtering out entries where all attribute diffs are
+# null-vs-empty (false positives from AWS API response normalization).
+drift="$(echo "$plan_json" | jq "$_normalize"'
+[
+  (.resource_drift // [])[] |
+  . as $entry |
+  if ($entry.change == null) then $entry
+  else
+    (($entry.change.before // {}) | normalize_empty) as $nb |
+    (($entry.change.after  // {}) | normalize_empty) as $na |
+    select($nb != $na)
+  end
+]
+')"
 drift_count="$(echo "$drift" | jq 'length')"
 
 if [[ "$drift_count" -eq 0 ]]; then
@@ -70,8 +100,9 @@ echo ""
 
 # Print human-readable drift summary showing changed attributes per resource.
 # The jq filter uses single quotes intentionally — jq handles \() interpolation.
+# Uses normalize_empty to skip null-vs-empty attribute diffs in display.
 # shellcheck disable=SC2016
-_drift_filter='
+_drift_filter="$_normalize"'
   .[] |
   "  \(.address)",
   (
@@ -81,7 +112,7 @@ _drift_filter='
       $before[] |
       . as $b |
       ($after | map(select(.key == $b.key)) | .[0]) as $a |
-      select(($a.value == $b.value) | not) |
+      select(($b.value | normalize_empty) != ($a.value | normalize_empty)) |
       "    \(.key): \($b.value | tojson) -> \($a.value | tojson)"
     ] | .[]
   ),


### PR DESCRIPTION
## Summary

- Adds a recursive `normalize_empty` jq function to `tf/drift-check.sh` that maps null-equivalent values (`null`, `[]`, `{}`, `false`, `0`, `""`) to `null` before comparing before/after state
- Drift entries where normalized before == normalized after are filtered out as false positives from AWS API response normalization
- Human-readable diff display also uses normalization to skip noise attributes

## Problem

After a clean `terraform apply` with 0 changes, drift detection reports 9 resources as drifted. All differences are AWS API response normalization — `null` vs `[]`, `{}`, `false`, `0`, `""`. This erodes trust in drift reports and causes users to dismiss real drift as noise.

## Test plan

- [x] `bash -n tf/drift-check.sh` — syntax valid
- [x] `shellcheck tf/drift-check.sh` — no warnings
- [x] All 27 existing tests still pass (no regressions)
- [x] **Test 11**: All-false-positive drift (null vs `[]`/`{}`/`false`/`0`/`""`) → exit 0, no drift.json
- [x] **Test 12**: Mixed real + false-positive drift → exit 2, drift_count=1, only real drift in report
- [x] **Test 13**: Nested null-vs-empty inside objects/arrays → exit 0

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)