### PR TITLE
fix: always write drift.json alongside stage-specific drift report

### DIFF
--- a/tests/test-drift-check.sh
+++ b/tests/test-drift-check.sh
@@ -273,16 +273,23 @@ else
   fail "stage flag: drift-cloud-provision.json not created"
 fi
 
-if [[ ! -f "$WORKDIR/outputs/drift.json" ]]; then
-  pass "stage flag: drift.json NOT created (correct)"
+if [[ -f "$WORKDIR/outputs/drift.json" ]]; then
+  pass "stage flag: drift.json ALSO created (Argo compat)"
 else
-  fail "stage flag: drift.json should not exist when --stage is used"
+  fail "stage flag: drift.json should also exist when --stage is used"
 fi
 
 if jq -e '.drift_detected == true' "$WORKDIR/outputs/drift-cloud-provision.json" >/dev/null 2>&1; then
   pass "stage flag: drift_detected is true"
 else
   fail "stage flag: drift_detected field missing or wrong"
+fi
+
+# Verify both files have identical content
+if diff -q "$WORKDIR/outputs/drift.json" "$WORKDIR/outputs/drift-cloud-provision.json" >/dev/null 2>&1; then
+  pass "stage flag: drift.json and drift-cloud-provision.json are identical"
+else
+  fail "stage flag: drift.json and drift-cloud-provision.json differ"
 fi
 
 # ============================================================
@@ -305,6 +312,12 @@ if [[ -f "$WORKDIR/outputs/drift-mystack.json" ]]; then
   pass "stage+ignore: drift-mystack.json created"
 else
   fail "stage+ignore: drift-mystack.json not created"
+fi
+
+if [[ -f "$WORKDIR/outputs/drift.json" ]]; then
+  pass "stage+ignore: drift.json ALSO created (Argo compat)"
+else
+  fail "stage+ignore: drift.json should also exist when --stage is used"
 fi
 
 if jq -e '.drift_detected == true' "$WORKDIR/outputs/drift-mystack.json" >/dev/null 2>&1; then

--- a/tf/drift-check.sh
+++ b/tf/drift-check.sh
@@ -50,7 +50,11 @@ fi
 # Resolve project root for output path
 : "${MARS_PROJECT_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 export MARS_PROJECT_ROOT
-echo "template_version=$(cat "$MARS_PROJECT_ROOT/.template_version" 2>/dev/null | tr -d '[:space:]')"
+if command -v getTfVar &>/dev/null; then
+  echo "template_version=$(getTfVar template_ref)"
+else
+  echo "template_version=unknown"
+fi
 
 OUTPUTS_DIR="$MARS_PROJECT_ROOT/outputs"
 
@@ -122,16 +126,18 @@ echo "$drift" | jq -r "$_drift_filter"
 
 # Write drift report
 mkdir -p "$OUTPUTS_DIR"
-if [[ -n "$stage_name" ]]; then
-  drift_file="$OUTPUTS_DIR/drift-${stage_name}.json"
-else
-  drift_file="$OUTPUTS_DIR/drift.json"
-fi
-jq -n --argjson drift "$drift" --argjson count "$drift_count" \
-  '{ drift_detected: true, drift_count: $count, resources: $drift }' \
-  > "$drift_file"
+_drift_report="$(jq -n --argjson drift "$drift" --argjson count "$drift_count" \
+  '{ drift_detected: true, drift_count: $count, resources: $drift }')"
 
-echo "Drift report written to $drift_file"
+# Always write drift.json (Argo artifact path expects this)
+echo "$_drift_report" > "$OUTPUTS_DIR/drift.json"
+
+if [[ -n "$stage_name" ]]; then
+  echo "$_drift_report" > "$OUTPUTS_DIR/drift-${stage_name}.json"
+  echo "Drift report written to $OUTPUTS_DIR/drift-${stage_name}.json (and drift.json)"
+else
+  echo "Drift report written to $OUTPUTS_DIR/drift.json"
+fi
 
 if [[ "$ignore_drift" == "true" ]]; then
   echo "WARNING: Drift ignored (--ignore-drift flag set)."


### PR DESCRIPTION
## Summary

- **Always write `drift.json`** when drift is detected, regardless of `--stage` flag. The Argo workflow uploads `drift.json` from S3, but `drift-refresh.sh` always passes `--stage`, so only `drift-{stage}.json` was written — the normalized report was never picked up.
- **Fix `template_version` logging**: replaced read of non-existent `.template_version` file with `getTfVar template_ref` (falls back to `"unknown"` when `shell_utils.sh` isn't sourced).
- Updated tests 8/9 to expect `drift.json` alongside stage-specific files, added content equality check.

Fixes #87

## Test plan

- [x] `bash -n tf/drift-check.sh` — syntax OK
- [x] `shellcheck tf/drift-check.sh` — clean
- [x] `bash tests/test-drift-check.sh` — 39/39 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)