### PR TITLE
fix: pass template version via env var instead of getTfVar

### DIFF
--- a/tests/test-drift-check.sh
+++ b/tests/test-drift-check.sh
@@ -476,6 +476,36 @@ else
   fail "nested: drift.json should not exist for nested false-positive drift"
 fi
 
+# ============================================================
+# Test 14: TEMPLATE_VERSION env var is used when set
+# ============================================================
+echo ""
+echo "Test 14: TEMPLATE_VERSION env var..."
+
+rm -rf "$WORKDIR/outputs"
+result="$(TEMPLATE_VERSION="v1.2.3" run_drift_check '{"resource_drift": []}')"
+
+if echo "$result" | grep -q "template_version=v1.2.3"; then
+  pass "env var: template_version=v1.2.3 printed"
+else
+  fail "env var: expected template_version=v1.2.3 in output"
+fi
+
+# ============================================================
+# Test 15: Without TEMPLATE_VERSION, falls back to unknown
+# ============================================================
+echo ""
+echo "Test 15: No TEMPLATE_VERSION falls back to unknown..."
+
+rm -rf "$WORKDIR/outputs"
+result="$(unset TEMPLATE_VERSION; run_drift_check '{"resource_drift": []}')"
+
+if echo "$result" | grep -q "template_version=unknown"; then
+  pass "fallback: template_version=unknown printed"
+else
+  fail "fallback: expected template_version=unknown in output"
+fi
+
 # --- Summary ---
 echo ""
 echo "================================"

--- a/tf/drift-check.sh
+++ b/tf/drift-check.sh
@@ -50,11 +50,7 @@ fi
 # Resolve project root for output path
 : "${MARS_PROJECT_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 export MARS_PROJECT_ROOT
-if command -v getTfVar &>/dev/null; then
-  echo "template_version=$(getTfVar template_ref)"
-else
-  echo "template_version=unknown"
-fi
+echo "template_version=${TEMPLATE_VERSION:-unknown}"
 
 OUTPUTS_DIR="$MARS_PROJECT_ROOT/outputs"
 

--- a/tf/drift-refresh.sh
+++ b/tf/drift-refresh.sh
@@ -45,4 +45,6 @@ terraform show -json refresh.tfplan > "$MARS_PROJECT_ROOT/outputs/tfplan-${lifec
 echo "Plan JSON written to $MARS_PROJECT_ROOT/outputs/tfplan-${lifecycle}.json"
 
 # Check for drift (always fails on drift — no --ignore-drift)
+export TEMPLATE_VERSION
+TEMPLATE_VERSION="$(getTfVar template_ref)"
 bash "$SCRIPT_DIR/drift-check.sh" refresh.tfplan --stage "$lifecycle"


### PR DESCRIPTION
## Summary

- `drift-check.sh` doesn't source `shell_utils.sh` (by design — it's standalone), so `getTfVar` was never available and `template_version` always printed `unknown`
- `drift-refresh.sh` now exports `TEMPLATE_VERSION=$(getTfVar template_ref)` before calling `drift-check.sh`
- `drift-check.sh` reads `${TEMPLATE_VERSION:-unknown}` — correct value when called from `drift-refresh.sh`, graceful fallback when standalone

Fixes #89

## Test plan

- [x] `bash -n tf/drift-check.sh` — syntax OK
- [x] `bash -n tf/drift-refresh.sh` — syntax OK
- [x] `shellcheck tf/drift-check.sh` — clean
- [x] `bash tests/test-drift-check.sh` — 41/41 passed (includes new tests 14-15 for env var and fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)