### PR TITLE
fix: gate drift-check on plan actionability and stamp template_version

### DIFF
--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -437,3 +437,12 @@ logTemplateVersion() {
   ver=$(getTfVar "template_ref")
   echo "template_version=${ver:-unknown}"
 }
+
+# exportTemplateVersion exports TEMPLATE_VERSION and logs template_version=<sha>.
+# Use in scripts that invoke child processes (e.g. drift-check.sh) which read
+# TEMPLATE_VERSION from env. For log-only use, prefer logTemplateVersion.
+exportTemplateVersion() {
+  export TEMPLATE_VERSION
+  TEMPLATE_VERSION="$(getTfVar template_ref)"
+  echo "template_version=${TEMPLATE_VERSION:-unknown}"
+}

--- a/tests/test-apply-scripts.sh
+++ b/tests/test-apply-scripts.sh
@@ -615,13 +615,15 @@ output="$(run_script apply-with-outputs.sh default --check-drift 2>&1)"
 exit_code=$?
 set -e
 
-# The parent script also logs template_version=, so drift-check should log
-# the same SHA (not "unknown"). Grep for exactly the parent-logged SHA.
+# Parent script logs once via exportTemplateVersion, child drift-check.sh
+# logs once via its own template_version=${TEMPLATE_VERSION:-unknown} echo.
+# Exact count 2 guards against the parent double-logging while the child is
+# silent (which a >=2 assertion would miss).
 tv_count="$(echo "$output" | grep -c "template_version=abcdef1234567890" || true)"
-if [[ "$tv_count" -ge 2 ]]; then
-  pass "apply-with-outputs: template_version=<sha> appears >=2 times (parent + child drift-check)"
+if [[ "$tv_count" -eq 2 ]]; then
+  pass "apply-with-outputs: template_version=<sha> appears exactly 2 times (parent + child drift-check)"
 else
-  fail "apply-with-outputs: template_version not propagated to drift-check; got $tv_count occurrences. Output: $output"
+  fail "apply-with-outputs: expected 2 template_version=<sha> lines, got $tv_count. Output: $output"
 fi
 
 if echo "$output" | grep -q "template_version=unknown"; then
@@ -642,10 +644,10 @@ exit_code=$?
 set -e
 
 tv_count="$(echo "$output" | grep -c "template_version=abcdef1234567890" || true)"
-if [[ "$tv_count" -ge 2 ]]; then
-  pass "apply-plan: template_version=<sha> appears >=2 times (parent + child drift-check)"
+if [[ "$tv_count" -eq 2 ]]; then
+  pass "apply-plan: template_version=<sha> appears exactly 2 times (parent + child drift-check)"
 else
-  fail "apply-plan: template_version not propagated to drift-check; got $tv_count occurrences. Output: $output"
+  fail "apply-plan: expected 2 template_version=<sha> lines, got $tv_count. Output: $output"
 fi
 
 if echo "$output" | grep -q "template_version=unknown"; then

--- a/tests/test-apply-scripts.sh
+++ b/tests/test-apply-scripts.sh
@@ -244,7 +244,10 @@ fi
 echo ""
 echo "Test 3: Drift-check mode with drift..."
 
-echo '{"resource_drift": [{"address": "aws_s3_bucket.test"}]}' > "$TF_SHOW_OUTPUT"
+echo '{
+  "resource_drift": [{"address": "aws_s3_bucket.test"}],
+  "resource_changes": [{"address": "aws_s3_bucket.test", "change": {"actions": ["update"]}}]
+}' > "$TF_SHOW_OUTPUT"
 
 set +e
 output="$(run_script apply-with-outputs.sh default --check-drift 2>&1)"
@@ -278,7 +281,10 @@ echo '{"resource_drift": []}' > "$TF_SHOW_OUTPUT"
 echo ""
 echo "Test 3b: Drift-check mode with --ignore-drift..."
 
-echo '{"resource_drift": [{"address": "aws_s3_bucket.test"}]}' > "$TF_SHOW_OUTPUT"
+echo '{
+  "resource_drift": [{"address": "aws_s3_bucket.test"}],
+  "resource_changes": [{"address": "aws_s3_bucket.test", "change": {"actions": ["update"]}}]
+}' > "$TF_SHOW_OUTPUT"
 
 set +e
 output="$(run_script apply-with-outputs.sh default --check-drift --ignore-drift 2>&1)"
@@ -410,7 +416,10 @@ fi
 echo ""
 echo "Test 7: apply-plan with drift detected..."
 
-echo '{"resource_drift": [{"address": "aws_vpc.main"}]}' > "$TF_SHOW_OUTPUT"
+echo '{
+  "resource_drift": [{"address": "aws_vpc.main"}],
+  "resource_changes": [{"address": "aws_vpc.main", "change": {"actions": ["update"]}}]
+}' > "$TF_SHOW_OUTPUT"
 echo "fake-plan" > "$PROJECT/tf/default/myplan.tfplan"
 
 set +e
@@ -505,6 +514,148 @@ if grep -q "terraform plan -refresh-only -out=refresh.tfplan" "$CMD_LOG"; then
 else
   fail "drift-refresh: plan command arguments wrong"
 fi
+
+# ============================================================
+# Issue #93 regression tests: Computed-attr drift + no-op plan
+# should not block apply.
+# ============================================================
+echo ""
+echo "=== Issue #93 regression: false-positive drift gate ==="
+
+# --- Test 12: apply-with-outputs.sh drift-check: drift + plan no-op → exit 0 ---
+echo ""
+echo "Test 12: apply-with-outputs drift-check with drift but plan no-op (issue #93)..."
+
+echo '{
+  "resource_drift": [
+    {"address": "module.aws_iam.aws_iam_role.writer"},
+    {"address": "module.aws_rds.aws_db_instance.primary"}
+  ],
+  "resource_changes": [
+    {"address": "module.aws_iam.aws_iam_role.writer", "change": {"actions": ["no-op"]}},
+    {"address": "module.aws_rds.aws_db_instance.primary", "change": {"actions": ["no-op"]}}
+  ]
+}' > "$TF_SHOW_OUTPUT"
+
+set +e
+output="$(run_script apply-with-outputs.sh default --check-drift 2>&1)"
+exit_code=$?
+set -e
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "noop-plan drift: exit code 0 (apply not blocked)"
+else
+  fail "noop-plan drift: expected exit 0, got $exit_code. Output: $output"
+fi
+
+if grep -q "terraform apply -input=false apply.tfplan" "$CMD_LOG"; then
+  pass "noop-plan drift: terraform apply proceeded"
+else
+  fail "noop-plan drift: terraform apply not called"
+fi
+
+if echo "$output" | grep -q "drift detected but plan has no actionable changes"; then
+  pass "noop-plan drift: INFO line printed"
+else
+  fail "noop-plan drift: expected INFO line about no actionable changes"
+fi
+
+# Reset
+echo '{"resource_drift": []}' > "$TF_SHOW_OUTPUT"
+
+# --- Test 13: apply-plan.sh drift-check: drift + plan no-op → exit 0 ---
+echo ""
+echo "Test 13: apply-plan drift-check with drift but plan no-op (issue #93)..."
+
+echo '{
+  "resource_drift": [{"address": "aws_vpc.main"}],
+  "resource_changes": [{"address": "aws_vpc.main", "change": {"actions": ["no-op"]}}]
+}' > "$TF_SHOW_OUTPUT"
+echo "fake-plan" > "$PROJECT/tf/default/myplan.tfplan"
+
+set +e
+output="$(run_script apply-plan.sh default --plan-file myplan --check-drift 2>&1)"
+exit_code=$?
+set -e
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "apply-plan noop drift: exit code 0"
+else
+  fail "apply-plan noop drift: expected exit 0, got $exit_code. Output: $output"
+fi
+
+if grep -q "terraform apply -input=false myplan.tfplan" "$CMD_LOG"; then
+  pass "apply-plan noop drift: terraform apply proceeded"
+else
+  fail "apply-plan noop drift: terraform apply not called"
+fi
+
+# Reset
+echo '{"resource_drift": []}' > "$TF_SHOW_OUTPUT"
+
+# ============================================================
+# Issue #93 regression: TEMPLATE_VERSION stamped in drift-check
+# child process (was appearing as "unknown" in production logs).
+# ============================================================
+echo ""
+echo "=== Issue #93 regression: TEMPLATE_VERSION stamping ==="
+
+# Stamp a template_ref into auto-vars so getTfVar picks it up.
+echo '{"cloud_provider": "aws", "template_ref": "abcdef1234567890"}' \
+  > "$PROJECT/tf/auto-vars/common.auto.tfvars.json"
+
+# --- Test 14: apply-with-outputs.sh drift-check: template_version stamped ---
+echo ""
+echo "Test 14: apply-with-outputs drift-check stamps template_version..."
+
+echo '{"resource_drift": []}' > "$TF_SHOW_OUTPUT"
+
+set +e
+output="$(run_script apply-with-outputs.sh default --check-drift 2>&1)"
+exit_code=$?
+set -e
+
+# The parent script also logs template_version=, so drift-check should log
+# the same SHA (not "unknown"). Grep for exactly the parent-logged SHA.
+tv_count="$(echo "$output" | grep -c "template_version=abcdef1234567890" || true)"
+if [[ "$tv_count" -ge 2 ]]; then
+  pass "apply-with-outputs: template_version=<sha> appears >=2 times (parent + child drift-check)"
+else
+  fail "apply-with-outputs: template_version not propagated to drift-check; got $tv_count occurrences. Output: $output"
+fi
+
+if echo "$output" | grep -q "template_version=unknown"; then
+  fail "apply-with-outputs: drift-check still logged template_version=unknown"
+else
+  pass "apply-with-outputs: no template_version=unknown in output"
+fi
+
+# --- Test 15: apply-plan.sh drift-check: template_version stamped ---
+echo ""
+echo "Test 15: apply-plan drift-check stamps template_version..."
+
+echo "fake-plan" > "$PROJECT/tf/default/myplan.tfplan"
+
+set +e
+output="$(run_script apply-plan.sh default --plan-file myplan --check-drift 2>&1)"
+exit_code=$?
+set -e
+
+tv_count="$(echo "$output" | grep -c "template_version=abcdef1234567890" || true)"
+if [[ "$tv_count" -ge 2 ]]; then
+  pass "apply-plan: template_version=<sha> appears >=2 times (parent + child drift-check)"
+else
+  fail "apply-plan: template_version not propagated to drift-check; got $tv_count occurrences. Output: $output"
+fi
+
+if echo "$output" | grep -q "template_version=unknown"; then
+  fail "apply-plan: drift-check still logged template_version=unknown"
+else
+  pass "apply-plan: no template_version=unknown in output"
+fi
+
+# Restore common auto-vars for any later tests (none currently, but defensive).
+echo '{"cloud_provider": "aws"}' > "$PROJECT/tf/auto-vars/common.auto.tfvars.json"
 
 # --- Summary ---
 echo ""

--- a/tests/test-drift-check.sh
+++ b/tests/test-drift-check.sh
@@ -578,7 +578,16 @@ echo "Test 17: Drift + plan has only data-source reads..."
 
 rm -rf "$WORKDIR/outputs"
 read_plan='{
-  "resource_drift": [{"address": "aws_s3_bucket.example"}],
+  "resource_drift": [
+    {
+      "address": "aws_s3_bucket.example",
+      "type": "aws_s3_bucket",
+      "change": {
+        "before": {"tags": {"env": "prod"}},
+        "after":  {"tags": {"env": "staging"}}
+      }
+    }
+  ],
   "resource_changes": [
     {"address": "data.aws_caller_identity.current", "change": {"actions": ["read"]}}
   ]
@@ -599,7 +608,18 @@ echo ""
 echo "Test 18: Drift + resource_changes key absent (refresh-only shape)..."
 
 rm -rf "$WORKDIR/outputs"
-refresh_only_plan='{"resource_drift": [{"address": "aws_s3_bucket.example"}]}'
+refresh_only_plan='{
+  "resource_drift": [
+    {
+      "address": "aws_s3_bucket.example",
+      "type": "aws_s3_bucket",
+      "change": {
+        "before": {"versioning": [{"enabled": true}]},
+        "after":  {"versioning": [{"enabled": false}]}
+      }
+    }
+  ]
+}'
 result="$(run_drift_check "$refresh_only_plan")"
 exit_code="$(echo "$result" | tail -1)"
 
@@ -650,25 +670,62 @@ else
 fi
 
 # ============================================================
-# Test 21: Drift + --ignore-drift + plan has changes — exit 0
-# --ignore-drift still wins over the gate (existing behavior).
+# Test 21: Flag ordering — --strict and --stage interleaved with other flags
+# Guards against arg-parser regressions where position matters.
 # ============================================================
 echo ""
-echo "Test 21: Drift + --ignore-drift with actionable plan..."
+echo "Test 21: Flag ordering variations..."
 
+# Variant A: --strict before --stage
 rm -rf "$WORKDIR/outputs"
-result="$(run_drift_check "$drift_plan" --ignore-drift)"
+result="$(run_drift_check "$refresh_only_plan" --strict --stage myorder-a)"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 2 ]]; then
+  pass "flag order A (--strict --stage): exit code 2"
+else
+  fail "flag order A (--strict --stage): expected exit 2, got $exit_code"
+fi
+
+if [[ -f "$WORKDIR/outputs/drift-myorder-a.json" ]]; then
+  pass "flag order A: drift-myorder-a.json created"
+else
+  fail "flag order A: stage file not created"
+fi
+
+# Variant B: --stage before --strict
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$refresh_only_plan" --stage myorder-b --strict)"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 2 ]]; then
+  pass "flag order B (--stage --strict): exit code 2"
+else
+  fail "flag order B (--stage --strict): expected exit 2, got $exit_code"
+fi
+
+if [[ -f "$WORKDIR/outputs/drift-myorder-b.json" ]]; then
+  pass "flag order B: drift-myorder-b.json created"
+else
+  fail "flag order B: stage file not created"
+fi
+
+# Variant C: --ignore-drift before --strict (ignore still wins)
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$refresh_only_plan" --ignore-drift --strict)"
 exit_code="$(echo "$result" | tail -1)"
 
 if [[ "$exit_code" -eq 0 ]]; then
-  pass "ignore-drift + changes: exit code 0 (ignore-drift wins)"
+  pass "flag order C (--ignore-drift --strict): exit 0 (ignore wins)"
 else
-  fail "ignore-drift + changes: expected exit 0, got $exit_code"
+  fail "flag order C (--ignore-drift --strict): expected exit 0, got $exit_code"
 fi
 
 # ============================================================
-# Test 22: Drift + --strict + --ignore-drift — exit 0
-# --ignore-drift takes precedence over --strict.
+# Test 22: Drift + --strict + --ignore-drift — exit 0 via ignore-drift path
+# --ignore-drift takes precedence over --strict. Assert BOTH exit 0 and the
+# WARNING log line fires — without the log check, a mutation making --strict
+# a silent no-op would still pass via the INFO branch.
 # ============================================================
 echo ""
 echo "Test 22: Drift + --strict + --ignore-drift..."
@@ -682,6 +739,58 @@ if [[ "$exit_code" -eq 0 ]]; then
 else
   fail "strict + ignore-drift: expected exit 0, got $exit_code"
 fi
+
+if echo "$result" | grep -q "WARNING: Drift ignored"; then
+  pass "strict + ignore-drift: WARNING line fired (ignore-drift path)"
+else
+  fail "strict + ignore-drift: expected 'WARNING: Drift ignored' log; got: $result"
+fi
+
+# Confirm we did NOT hit the INFO branch (mutually exclusive with ignore-drift).
+if echo "$result" | grep -q "drift detected but plan has no actionable changes"; then
+  fail "strict + ignore-drift: INFO branch fired (should be WARNING)"
+else
+  pass "strict + ignore-drift: INFO branch did NOT fire"
+fi
+
+# ============================================================
+# Tests 23-27: Action-kind coverage — every actionable action in
+# resource_changes[] must block apply. Guards against a mutation that
+# accidentally treats delete/create/replace as non-actionable.
+# ============================================================
+for action_case in \
+  'delete|["delete"]' \
+  'create|["create"]' \
+  'replace-forward|["create","delete"]' \
+  'replace-reverse|["delete","create"]' \
+  'missing-actions|null'; do
+  name="${action_case%%|*}"
+  actions="${action_case#*|}"
+  echo ""
+  echo "Test action-kind: $name (actions=$actions)..."
+
+  rm -rf "$WORKDIR/outputs"
+  if [[ "$actions" == "null" ]]; then
+    # Missing change.actions entirely — fail-safe should treat as actionable.
+    action_plan='{
+      "resource_drift": [{"address": "aws_x.y", "change": {"before": {"k": "a"}, "after": {"k": "b"}}}],
+      "resource_changes": [{"address": "aws_x.y", "change": {}}]
+    }'
+  else
+    action_plan='{
+      "resource_drift": [{"address": "aws_x.y", "change": {"before": {"k": "a"}, "after": {"k": "b"}}}],
+      "resource_changes": [{"address": "aws_x.y", "change": {"actions": '"$actions"'}}]
+    }'
+  fi
+  result="$(run_drift_check "$action_plan")"
+  exit_code="$(echo "$result" | tail -1)"
+
+  if [[ "$exit_code" -eq 2 ]]; then
+    pass "action-kind $name: exit 2 (treated as actionable)"
+  else
+    fail "action-kind $name: expected exit 2, got $exit_code. Output: $result"
+  fi
+done
 
 # --- Summary ---
 echo ""

--- a/tests/test-drift-check.sh
+++ b/tests/test-drift-check.sh
@@ -94,7 +94,13 @@ echo ""
 echo "Test 2: Drift detected..."
 
 rm -rf "$WORKDIR/outputs"
-drift_plan='{"resource_drift": [{"address": "aws_s3_bucket.example", "type": "aws_s3_bucket"}]}'
+# drift_plan includes an actionable resource_changes entry so the plan-change
+# gate in drift-check.sh treats drift as apply-blocking (exit 2). Tests that
+# want to exercise the "drift but plan is no-op" gate use other fixtures below.
+drift_plan='{
+  "resource_drift": [{"address": "aws_s3_bucket.example", "type": "aws_s3_bucket"}],
+  "resource_changes": [{"address": "aws_s3_bucket.example", "change": {"actions": ["update"]}}]
+}'
 result="$(run_drift_check "$drift_plan")"
 exit_code="$(echo "$result" | tail -1)"
 
@@ -399,24 +405,29 @@ echo ""
 echo "Test 12: Mixed real and false-positive drift..."
 
 rm -rf "$WORKDIR/outputs"
-mixed_plan='{"resource_drift": [
-  {
-    "address": "aws_s3_bucket.false_positive",
-    "type": "aws_s3_bucket",
-    "change": {
-      "before": {"cors_rule": null, "tags": {"env": "prod"}},
-      "after":  {"cors_rule": [],   "tags": {"env": "prod"}}
+mixed_plan='{
+  "resource_drift": [
+    {
+      "address": "aws_s3_bucket.false_positive",
+      "type": "aws_s3_bucket",
+      "change": {
+        "before": {"cors_rule": null, "tags": {"env": "prod"}},
+        "after":  {"cors_rule": [],   "tags": {"env": "prod"}}
+      }
+    },
+    {
+      "address": "aws_instance.real_drift",
+      "type": "aws_instance",
+      "change": {
+        "before": {"instance_type": "t3.micro", "tags": {"Name": "old"}},
+        "after":  {"instance_type": "t3.small", "tags": {"Name": "new"}}
+      }
     }
-  },
-  {
-    "address": "aws_instance.real_drift",
-    "type": "aws_instance",
-    "change": {
-      "before": {"instance_type": "t3.micro", "tags": {"Name": "old"}},
-      "after":  {"instance_type": "t3.small", "tags": {"Name": "new"}}
-    }
-  }
-]}'
+  ],
+  "resource_changes": [
+    {"address": "aws_instance.real_drift", "change": {"actions": ["update"]}}
+  ]
+}'
 result="$(run_drift_check "$mixed_plan")"
 exit_code="$(echo "$result" | tail -1)"
 
@@ -504,6 +515,172 @@ if echo "$result" | grep -q "template_version=unknown"; then
   pass "fallback: template_version=unknown printed"
 else
   fail "fallback: expected template_version=unknown in output"
+fi
+
+# ============================================================
+# Test 16: Drift + resource_changes all no-op — exit 0 (INFO-only)
+# Reproduces the issue #93 production scenario: terraform plan reports
+# "No changes" but resource_drift lists provider-populated Computed attrs.
+# Drift should be reported but not block apply.
+# ============================================================
+echo ""
+echo "Test 16: Drift + plan is no-op (Computed-attr false-positive gate)..."
+
+rm -rf "$WORKDIR/outputs"
+noop_plan='{
+  "resource_drift": [
+    {
+      "address": "module.aws_iam.aws_iam_role.writer",
+      "type": "aws_iam_role",
+      "change": {
+        "before": {"managed_policy_arns": []},
+        "after":  {"managed_policy_arns": ["arn:aws:iam::aws:policy/example"]}
+      }
+    }
+  ],
+  "resource_changes": [
+    {"address": "module.aws_iam.aws_iam_role.writer", "change": {"actions": ["no-op"]}}
+  ]
+}'
+result="$(run_drift_check "$noop_plan")"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "noop-plan: exit code 0 (not blocking apply)"
+else
+  fail "noop-plan: expected exit 0, got $exit_code"
+fi
+
+if echo "$result" | grep -q "drift detected but plan has no actionable changes"; then
+  pass "noop-plan: INFO line printed"
+else
+  fail "noop-plan: expected INFO line about no actionable changes"
+fi
+
+if [[ -f "$WORKDIR/outputs/drift.json" ]]; then
+  pass "noop-plan: drift.json still written (diagnostic artifact)"
+else
+  fail "noop-plan: drift.json should exist even when not blocking"
+fi
+
+if jq -e '.drift_detected == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "noop-plan: drift_detected is true in report"
+else
+  fail "noop-plan: drift_detected should still be true"
+fi
+
+# ============================================================
+# Test 17: Drift + resource_changes all "read" — exit 0
+# Data-source refreshes are not actionable.
+# ============================================================
+echo ""
+echo "Test 17: Drift + plan has only data-source reads..."
+
+rm -rf "$WORKDIR/outputs"
+read_plan='{
+  "resource_drift": [{"address": "aws_s3_bucket.example"}],
+  "resource_changes": [
+    {"address": "data.aws_caller_identity.current", "change": {"actions": ["read"]}}
+  ]
+}'
+result="$(run_drift_check "$read_plan")"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "read-only: exit code 0"
+else
+  fail "read-only: expected exit 0, got $exit_code"
+fi
+
+# ============================================================
+# Test 18: Drift + resource_changes absent — exit 0
+# ============================================================
+echo ""
+echo "Test 18: Drift + resource_changes key absent (refresh-only shape)..."
+
+rm -rf "$WORKDIR/outputs"
+refresh_only_plan='{"resource_drift": [{"address": "aws_s3_bucket.example"}]}'
+result="$(run_drift_check "$refresh_only_plan")"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "refresh-only shape: exit code 0"
+else
+  fail "refresh-only shape: expected exit 0, got $exit_code"
+fi
+
+# ============================================================
+# Test 19: Drift + --strict + resource_changes absent — exit 2
+# drift-refresh.sh invariant: standalone alarm still fires.
+# ============================================================
+echo ""
+echo "Test 19: Drift + --strict + no resource_changes (refresh-only alarm)..."
+
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$refresh_only_plan" --strict)"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 2 ]]; then
+  pass "strict refresh-only: exit code 2"
+else
+  fail "strict refresh-only: expected exit 2, got $exit_code"
+fi
+
+if [[ -f "$WORKDIR/outputs/drift.json" ]]; then
+  pass "strict refresh-only: drift.json created"
+else
+  fail "strict refresh-only: drift.json not created"
+fi
+
+# ============================================================
+# Test 20: Drift + --strict + resource_changes all no-op — exit 2
+# --strict bypasses the plan-change gate entirely.
+# ============================================================
+echo ""
+echo "Test 20: Drift + --strict + plan all no-op..."
+
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$noop_plan" --strict)"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 2 ]]; then
+  pass "strict noop-plan: exit code 2"
+else
+  fail "strict noop-plan: expected exit 2, got $exit_code"
+fi
+
+# ============================================================
+# Test 21: Drift + --ignore-drift + plan has changes — exit 0
+# --ignore-drift still wins over the gate (existing behavior).
+# ============================================================
+echo ""
+echo "Test 21: Drift + --ignore-drift with actionable plan..."
+
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$drift_plan" --ignore-drift)"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "ignore-drift + changes: exit code 0 (ignore-drift wins)"
+else
+  fail "ignore-drift + changes: expected exit 0, got $exit_code"
+fi
+
+# ============================================================
+# Test 22: Drift + --strict + --ignore-drift — exit 0
+# --ignore-drift takes precedence over --strict.
+# ============================================================
+echo ""
+echo "Test 22: Drift + --strict + --ignore-drift..."
+
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$drift_plan" --strict --ignore-drift)"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "strict + ignore-drift: exit code 0"
+else
+  fail "strict + ignore-drift: expected exit 0, got $exit_code"
 fi
 
 # --- Summary ---

--- a/tests/test-template-version.sh
+++ b/tests/test-template-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Tests for logTemplateVersion() in shell_utils.sh.
+# Tests for logTemplateVersion() and exportTemplateVersion() in shell_utils.sh.
 
 PASS=0
 FAIL=0
@@ -103,6 +103,85 @@ if [[ "$output" == "template_version=unknown" ]]; then
   pass "empty value: outputs template_version=unknown"
 else
   fail "empty value: expected 'template_version=unknown', got '$output'"
+fi
+
+# ============================================================
+# Test 5: exportTemplateVersion logs AND exports TEMPLATE_VERSION
+# ============================================================
+echo "Test 5: exportTemplateVersion exports env var..."
+
+set_template_ref "abcdef12"
+
+# Child process sees TEMPLATE_VERSION from env after exportTemplateVersion runs.
+child_sees="$(
+  export MARS_PROJECT_ROOT="$PROJECT"
+  # shellcheck disable=SC1091
+  . "$PROJECT/shell_utils.sh"
+  exportTemplateVersion >/dev/null
+  bash -c 'echo "${TEMPLATE_VERSION:-NOTSET}"'
+)"
+
+if [[ "$child_sees" == "abcdef12" ]]; then
+  pass "export: child process sees TEMPLATE_VERSION=abcdef12"
+else
+  fail "export: expected child to see 'abcdef12', got '$child_sees'"
+fi
+
+# Also still logs the same line.
+log_output="$(
+  export MARS_PROJECT_ROOT="$PROJECT"
+  # shellcheck disable=SC1091
+  . "$PROJECT/shell_utils.sh"
+  exportTemplateVersion
+)"
+
+if [[ "$log_output" == "template_version=abcdef12" ]]; then
+  pass "export: log line matches template_version=abcdef12"
+else
+  fail "export: expected log 'template_version=abcdef12', got '$log_output'"
+fi
+
+# ============================================================
+# Test 6: exportTemplateVersion falls back to unknown when template_ref missing
+# ============================================================
+echo "Test 6: exportTemplateVersion falls back to unknown..."
+
+echo '{}' > "$PROJECT/tf/auto-vars/common.auto.tfvars.json"
+
+log_output="$(
+  export MARS_PROJECT_ROOT="$PROJECT"
+  # shellcheck disable=SC1091
+  . "$PROJECT/shell_utils.sh"
+  exportTemplateVersion
+)"
+
+if [[ "$log_output" == "template_version=unknown" ]]; then
+  pass "export fallback: logs template_version=unknown"
+else
+  fail "export fallback: expected 'template_version=unknown', got '$log_output'"
+fi
+
+# ============================================================
+# Test 7: logTemplateVersion does NOT export TEMPLATE_VERSION
+# Guards against accidental cross-contamination from the two helpers.
+# ============================================================
+echo "Test 7: logTemplateVersion does not export..."
+
+set_template_ref "should-not-leak"
+
+child_sees="$(
+  export MARS_PROJECT_ROOT="$PROJECT"
+  unset TEMPLATE_VERSION
+  # shellcheck disable=SC1091
+  . "$PROJECT/shell_utils.sh"
+  logTemplateVersion >/dev/null
+  bash -c 'echo "${TEMPLATE_VERSION:-NOTSET}"'
+)"
+
+if [[ "$child_sees" == "NOTSET" ]]; then
+  pass "logTemplateVersion: does not export (child sees NOTSET)"
+else
+  fail "logTemplateVersion: unexpectedly exported TEMPLATE_VERSION; child saw '$child_sees'"
 fi
 
 # --- Summary ---

--- a/tf/apply-plan.sh
+++ b/tf/apply-plan.sh
@@ -53,7 +53,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export MARS_PROJECT_ROOT
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
-logTemplateVersion
+exportTemplateVersion
 
 # Source utils.sh (expects $1 = workspace/lifecycle)
 set -- "$lifecycle"

--- a/tf/apply-with-outputs.sh
+++ b/tf/apply-with-outputs.sh
@@ -44,7 +44,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export MARS_PROJECT_ROOT
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
-logTemplateVersion
+exportTemplateVersion
 
 captureOutputs() {
   mkdir -p "$MARS_PROJECT_ROOT/outputs"

--- a/tf/drift-check.sh
+++ b/tf/drift-check.sh
@@ -100,22 +100,24 @@ drift="$(echo "$plan_json" | jq "$_normalize"'
 ')"
 drift_count="$(echo "$drift" | jq 'length')"
 
+if [[ "$drift_count" -eq 0 ]]; then
+  echo "No resource drift detected."
+  exit 0
+fi
+
 # Count plan changes that terraform would actually apply. Equivalent to
 # `terraform plan -detailed-exitcode` exit 2 vs 0. Computed attributes show up
 # in resource_drift but not in resource_changes, so this filters the common
 # false-positive pattern of provider-populated attrs (inline_policy,
 # managed_policy_arns, association_id, latest_restorable_time, etc.).
+# Missing/null change.actions falls through the select and counts as
+# actionable (fail-safe toward blocking apply).
 has_plan_changes="$(echo "$plan_json" | jq '
   [
     (.resource_changes // [])[] |
     select(.change.actions != ["no-op"] and .change.actions != ["read"])
   ] | length
 ')"
-
-if [[ "$drift_count" -eq 0 ]]; then
-  echo "No resource drift detected."
-  exit 0
-fi
 
 echo "Drift detected: $drift_count resource(s) have drifted."
 echo ""

--- a/tf/drift-check.sh
+++ b/tf/drift-check.sh
@@ -2,12 +2,20 @@
 # shellcheck shell=bash
 # drift-check.sh — Check a terraform plan file for resource drift.
 #
-# Usage: bash drift-check.sh <plan-file> [--ignore-drift]
+# Usage: bash drift-check.sh <plan-file> [--ignore-drift] [--stage <name>] [--strict]
 #
 # Exit codes:
-#   0 — No drift detected (or drift ignored via --ignore-drift)
+#   0 — No drift detected, drift ignored via --ignore-drift, or drift found but
+#       the plan has no actionable changes (all resource_changes are no-op/read)
+#       and --strict was not passed. Drift is still reported and drift.json is
+#       still written in all these cases.
 #   1 — Error (missing plan file, jq failure, etc.)
-#   2 — Drift detected
+#   2 — Drift detected AND (--strict OR plan has actionable changes).
+#
+# Refresh-only plans (from `terraform plan -refresh-only`) always have no
+# actionable changes, so drift-check is informational on them by default. Pass
+# --strict to alarm on any drift regardless — used by drift-refresh.sh as a
+# standalone manual-edit detector.
 #
 # If drift is found, writes a JSON report to $MARS_PROJECT_ROOT/outputs/drift.json.
 # Does NOT source utils.sh — operates on a plan file already in the CWD.
@@ -15,7 +23,7 @@
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: drift-check.sh <plan-file> [--ignore-drift]" >&2
+  echo "Usage: drift-check.sh <plan-file> [--ignore-drift] [--stage <name>] [--strict]" >&2
   exit 1
 fi
 
@@ -24,9 +32,11 @@ shift
 
 ignore_drift=false
 stage_name=""
+strict=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --ignore-drift) ignore_drift=true; shift ;;
+    --strict) strict=true; shift ;;
     --stage)
       if [[ $# -lt 2 ]]; then
         echo "ERROR: --stage requires a value" >&2
@@ -90,6 +100,18 @@ drift="$(echo "$plan_json" | jq "$_normalize"'
 ')"
 drift_count="$(echo "$drift" | jq 'length')"
 
+# Count plan changes that terraform would actually apply. Equivalent to
+# `terraform plan -detailed-exitcode` exit 2 vs 0. Computed attributes show up
+# in resource_drift but not in resource_changes, so this filters the common
+# false-positive pattern of provider-populated attrs (inline_policy,
+# managed_policy_arns, association_id, latest_restorable_time, etc.).
+has_plan_changes="$(echo "$plan_json" | jq '
+  [
+    (.resource_changes // [])[] |
+    select(.change.actions != ["no-op"] and .change.actions != ["read"])
+  ] | length
+')"
+
 if [[ "$drift_count" -eq 0 ]]; then
   echo "No resource drift detected."
   exit 0
@@ -137,6 +159,11 @@ fi
 
 if [[ "$ignore_drift" == "true" ]]; then
   echo "WARNING: Drift ignored (--ignore-drift flag set)."
+  exit 0
+fi
+
+if [[ "$strict" != "true" && "$has_plan_changes" -eq 0 ]]; then
+  echo "INFO: drift detected but plan has no actionable changes (0 to add/change/destroy); not blocking apply."
   exit 0
 fi
 

--- a/tf/drift-refresh.sh
+++ b/tf/drift-refresh.sh
@@ -26,7 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export MARS_PROJECT_ROOT
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
-logTemplateVersion
+exportTemplateVersion
 
 # Source utils.sh (expects $1 = workspace/lifecycle)
 set -- "$lifecycle"
@@ -44,7 +44,7 @@ mkdir -p "$MARS_PROJECT_ROOT/outputs"
 terraform show -json refresh.tfplan > "$MARS_PROJECT_ROOT/outputs/tfplan-${lifecycle}.json"
 echo "Plan JSON written to $MARS_PROJECT_ROOT/outputs/tfplan-${lifecycle}.json"
 
-# Check for drift (always fails on drift — no --ignore-drift)
-export TEMPLATE_VERSION
-TEMPLATE_VERSION="$(getTfVar template_ref)"
-bash "$SCRIPT_DIR/drift-check.sh" refresh.tfplan --stage "$lifecycle"
+# Standalone drift alarm: --strict bypasses the plan-actionability gate in
+# drift-check.sh, since -refresh-only plans by definition have no actionable
+# changes but we still want to alarm on any real drift here.
+bash "$SCRIPT_DIR/drift-check.sh" refresh.tfplan --stage "$lifecycle" --strict


### PR DESCRIPTION
## Summary

Fixes two linked bugs in the `drift-check` step of the custom-stack apply
pipeline that bit a real production deploy (session `sess_v2_9Up7YUKIIdjW`,
apply `ccs-58806745-*`).

### Bug 1: false-positive drift on Computed attributes

`terraform plan` reports "Plan: 0 to add, 0 to change, 0 to destroy. No
changes." — then `drift-check.sh` flags resources as drifted and exits 2,
blocking apply. Every flagged attribute is Computed or provider-populated
(e.g., `inline_policy`, `managed_policy_arns`, `latest_restorable_time`,
`association_id`, `route`, `domain`). `resource_drift[]` captures refresh-time
diffs, but only `resource_changes[]` is authoritative for what terraform will
actually apply.

Fix: `drift-check.sh` now inspects `resource_changes[]` and demotes drift to
INFO (exit 0) when all actions are `no-op`/`read`. Drift is still reported
and `drift.json` is still written. Equivalent to `terraform plan
-detailed-exitcode` 2 vs 0, but computed self-contained so it works for
pre-built `.tfplan` files in `apply-plan.sh`.

Added `--strict` flag for the standalone `drift-refresh.sh` alarm path,
which uses `-refresh-only` plans that by definition have no actionable
`resource_changes[]` but still need to alert on real manual-edit drift.

### Bug 2: `template_version=unknown` in drift-check logs

`apply-with-outputs.sh` and `apply-plan.sh` invoke `drift-check.sh` as a
child process without exporting `TEMPLATE_VERSION`, so drift-check logs
`unknown` in production even when the parent scripts log the real SHA.

Fix: new `exportTemplateVersion` helper in `shell_utils.sh` that both logs
and exports the env var; wired into the three drift-invoking scripts.
`logTemplateVersion` is left untouched — 8+ unrelated callers (`apply.sh`,
`destroy.sh`, `plan.sh`, etc.) don't need the env side effect.

## End-to-end reproduction of the production scenario

```
--- default mode (apply path, new behavior) ---
template_version=prod-sha-abc123
Drift detected: 3 resource(s) have drifted.
  module.aws_iam.aws_iam_role.writer
    managed_policy_arns: [] -> [...]
  module.aws_cognito.aws_cognito_user_pool.this
    domain: "" -> "io-9up7yukiidjw"
  module.aws_rds.aws_db_instance.primary
    latest_restorable_time: ... -> ...
Drift report written to .../drift-custom-stack-provision.json (and drift.json)
INFO: drift detected but plan has no actionable changes (0 to add/change/destroy); not blocking apply.
default exit: 0   ← was exit 2 before this fix

--- --strict mode (drift-refresh path, preserved) ---
(same output)
strict exit: 2   ← preserved for standalone alarm use
```

## Test plan

- [x] `bash tests/test-drift-check.sh` — 52 passed (14 new cases covering
  the plan-change gate, `--strict` mode, and the issue #93 reproduction)
- [x] `bash tests/test-apply-scripts.sh` — 45 passed (4 new cases for
  no-op drift not blocking apply + TEMPLATE_VERSION propagation to child
  drift-check)
- [x] `bash tests/test-template-version.sh` — 8 passed (4 new cases for
  `exportTemplateVersion` export semantics + guard that
  `logTemplateVersion` does NOT leak)
- [x] `bash -n` and `shellcheck` clean on all modified files (no new
  warnings introduced)
- [x] End-to-end reproduction of issue #93 production scenario exits 0
  in default mode, 2 in `--strict` mode

## Out of scope (noted in issue, tracked separately)

- `ignore_changes` on Computed attributes in
  `luthersystems/insideout-terraform-presets` (defense in depth)
- `reliable2` bootstrap-credentials-dropped on stale `DurableManagementReady`
  in the apply-from-plan path

Closes #93