### PR TITLE
feat: log presets_ref alongside template_ref and surface both in drift.json

### DIFF
--- a/prepare-custom-stack.sh
+++ b/prepare-custom-stack.sh
@@ -10,6 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shell_utils provides: getTfVar, mustGetTfVar, log helpers, etc.
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 logTemplateVersion
+logPresetsVersion
 
 log() { echo "[prepare-custom-stack] $*" >&2; }
 

--- a/run-ansible.sh
+++ b/run-ansible.sh
@@ -16,6 +16,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${MARS_PROJECT_ROOT:=$SCRIPT_DIR}"
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 logTemplateVersion
+logPresetsVersion
 echo "docker version"
 docker --version
 

--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -446,3 +446,20 @@ exportTemplateVersion() {
   TEMPLATE_VERSION="$(getTfVar template_ref)"
   echo "template_version=${TEMPLATE_VERSION:-unknown}"
 }
+
+# logPresetsVersion logs the insideout-terraform-presets module version.
+# Reads presets_ref from TF auto-vars (written alongside template_ref).
+logPresetsVersion() {
+  local ver
+  ver=$(getTfVar "presets_ref")
+  echo "presets_version=${ver:-unknown}"
+}
+
+# exportPresetsVersion exports PRESETS_VERSION and logs presets_version=<sha>.
+# Use in scripts that invoke child processes (e.g. drift-check.sh) which read
+# PRESETS_VERSION from env. For log-only use, prefer logPresetsVersion.
+exportPresetsVersion() {
+  export PRESETS_VERSION
+  PRESETS_VERSION="$(getTfVar presets_ref)"
+  echo "presets_version=${PRESETS_VERSION:-unknown}"
+}

--- a/tests/test-apply-scripts.sh
+++ b/tests/test-apply-scripts.sh
@@ -240,6 +240,35 @@ else
   fail "drift-check mode: default.json content wrong"
 fi
 
+# drift.json stub: no drift → drift-check.sh does not write a report,
+# apply-with-outputs.sh writes a uniform full-schema stub so consumers always
+# see the same fields. template_ref / presets_ref are not in auto-vars for
+# this test, so provenance fields should be null (not absent).
+if jq -e '.drift_detected == false' "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift-check mode: stub drift.json has drift_detected=false"
+else
+  fail "drift-check mode: stub drift.json missing drift_detected=false"
+fi
+
+if jq -e '.actionable == false' "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift-check mode: stub drift.json has actionable=false"
+else
+  fail "drift-check mode: stub drift.json missing actionable=false"
+fi
+
+if jq -e '.template_version == null and .presets_version == null' \
+   "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift-check mode: stub drift.json has null provenance fields (env unset)"
+else
+  fail "drift-check mode: stub drift.json provenance fields wrong"
+fi
+
+if jq -e '.resources == []' "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift-check mode: stub drift.json has empty resources array"
+else
+  fail "drift-check mode: stub drift.json resources field wrong"
+fi
+
 # --- Test 3: Drift-check mode + drift detected → exit 2, apply not called ---
 echo ""
 echo "Test 3: Drift-check mode with drift..."
@@ -602,12 +631,13 @@ echo '{"resource_drift": []}' > "$TF_SHOW_OUTPUT"
 # ============================================================
 # Issue #93 regression: TEMPLATE_VERSION stamped in drift-check
 # child process (was appearing as "unknown" in production logs).
+# PRESETS_VERSION mirrors this via exportPresetsVersion.
 # ============================================================
 echo ""
-echo "=== Issue #93 regression: TEMPLATE_VERSION stamping ==="
+echo "=== Issue #93 regression: TEMPLATE_VERSION + PRESETS_VERSION stamping ==="
 
-# Stamp a template_ref into auto-vars so getTfVar picks it up.
-echo '{"cloud_provider": "aws", "template_ref": "abcdef1234567890"}' \
+# Stamp both refs into auto-vars so getTfVar picks them up.
+echo '{"cloud_provider": "aws", "template_ref": "abcdef1234567890", "presets_ref": "v1.4.2"}' \
   > "$PROJECT/tf/auto-vars/common.auto.tfvars.json"
 
 # --- Test 14: apply-with-outputs.sh drift-check: template_version stamped ---
@@ -624,18 +654,42 @@ set -e
 # Parent script logs once via exportTemplateVersion, child drift-check.sh
 # logs once via its own template_version=${TEMPLATE_VERSION:-unknown} echo.
 # Exact count 2 guards against the parent double-logging while the child is
-# silent (which a >=2 assertion would miss).
-tv_count="$(echo "$output" | grep -c "template_version=abcdef1234567890" || true)"
+# silent (which a >=2 assertion would miss). Use -F (fixed string) so the
+# literal dots in the version ref aren't regex-interpreted.
+tv_count="$(echo "$output" | grep -cF "template_version=abcdef1234567890" || true)"
 if [[ "$tv_count" -eq 2 ]]; then
   pass "apply-with-outputs: template_version=<sha> appears exactly 2 times (parent + child drift-check)"
 else
   fail "apply-with-outputs: expected 2 template_version=<sha> lines, got $tv_count. Output: $output"
 fi
 
-if echo "$output" | grep -q "template_version=unknown"; then
+if echo "$output" | grep -qF "template_version=unknown"; then
   fail "apply-with-outputs: drift-check still logged template_version=unknown"
 else
   pass "apply-with-outputs: no template_version=unknown in output"
+fi
+
+pv_count="$(echo "$output" | grep -cF "presets_version=v1.4.2" || true)"
+if [[ "$pv_count" -eq 2 ]]; then
+  pass "apply-with-outputs: presets_version=<ref> appears exactly 2 times (parent + child drift-check)"
+else
+  fail "apply-with-outputs: expected 2 presets_version=<ref> lines, got $pv_count. Output: $output"
+fi
+
+if echo "$output" | grep -qF "presets_version=unknown"; then
+  fail "apply-with-outputs: drift-check still logged presets_version=unknown"
+else
+  pass "apply-with-outputs: no presets_version=unknown in output"
+fi
+
+# Integration assertion: drift.json written through the apply-with-outputs
+# → drift-check.sh chain contains both provenance fields populated from the
+# exported env vars.
+if jq -e '.template_version == "abcdef1234567890" and .presets_version == "v1.4.2"' \
+   "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then
+  pass "apply-with-outputs: drift.json contains both provenance fields via env propagation"
+else
+  fail "apply-with-outputs: drift.json missing or wrong provenance fields. Contents: $(cat "$PROJECT/outputs/drift.json" 2>&1)"
 fi
 
 # --- Test 15: apply-plan.sh drift-check: template_version stamped ---
@@ -649,17 +703,30 @@ output="$(run_script apply-plan.sh default --plan-file myplan --check-drift 2>&1
 exit_code=$?
 set -e
 
-tv_count="$(echo "$output" | grep -c "template_version=abcdef1234567890" || true)"
+tv_count="$(echo "$output" | grep -cF "template_version=abcdef1234567890" || true)"
 if [[ "$tv_count" -eq 2 ]]; then
   pass "apply-plan: template_version=<sha> appears exactly 2 times (parent + child drift-check)"
 else
   fail "apply-plan: expected 2 template_version=<sha> lines, got $tv_count. Output: $output"
 fi
 
-if echo "$output" | grep -q "template_version=unknown"; then
+if echo "$output" | grep -qF "template_version=unknown"; then
   fail "apply-plan: drift-check still logged template_version=unknown"
 else
   pass "apply-plan: no template_version=unknown in output"
+fi
+
+pv_count="$(echo "$output" | grep -cF "presets_version=v1.4.2" || true)"
+if [[ "$pv_count" -eq 2 ]]; then
+  pass "apply-plan: presets_version=<ref> appears exactly 2 times (parent + child drift-check)"
+else
+  fail "apply-plan: expected 2 presets_version=<ref> lines, got $pv_count. Output: $output"
+fi
+
+if echo "$output" | grep -qF "presets_version=unknown"; then
+  fail "apply-plan: drift-check still logged presets_version=unknown"
+else
+  pass "apply-plan: no presets_version=unknown in output"
 fi
 
 # Restore common auto-vars for any later tests (none currently, but defensive).

--- a/tests/test-drift-check.sh
+++ b/tests/test-drift-check.sh
@@ -500,13 +500,13 @@ else
 fi
 
 # ============================================================
-# Test 14: TEMPLATE_VERSION env var is used when set
+# Test 14: TEMPLATE_VERSION / PRESETS_VERSION env vars are used when set
 # ============================================================
 echo ""
-echo "Test 14: TEMPLATE_VERSION env var..."
+echo "Test 14: TEMPLATE_VERSION + PRESETS_VERSION env vars..."
 
 rm -rf "$WORKDIR/outputs"
-result="$(TEMPLATE_VERSION="v1.2.3" run_drift_check '{"resource_drift": []}')"
+result="$(TEMPLATE_VERSION="v1.2.3" PRESETS_VERSION="v1.4.2" run_drift_check '{"resource_drift": []}')"
 
 if echo "$result" | grep -q "template_version=v1.2.3"; then
   pass "env var: template_version=v1.2.3 printed"
@@ -514,19 +514,31 @@ else
   fail "env var: expected template_version=v1.2.3 in output"
 fi
 
+if echo "$result" | grep -q "presets_version=v1.4.2"; then
+  pass "env var: presets_version=v1.4.2 printed"
+else
+  fail "env var: expected presets_version=v1.4.2 in output"
+fi
+
 # ============================================================
-# Test 15: Without TEMPLATE_VERSION, falls back to unknown
+# Test 15: Without env vars, falls back to unknown
 # ============================================================
 echo ""
-echo "Test 15: No TEMPLATE_VERSION falls back to unknown..."
+echo "Test 15: No TEMPLATE_VERSION/PRESETS_VERSION falls back to unknown..."
 
 rm -rf "$WORKDIR/outputs"
-result="$(unset TEMPLATE_VERSION; run_drift_check '{"resource_drift": []}')"
+result="$(unset TEMPLATE_VERSION PRESETS_VERSION; run_drift_check '{"resource_drift": []}')"
 
 if echo "$result" | grep -q "template_version=unknown"; then
   pass "fallback: template_version=unknown printed"
 else
   fail "fallback: expected template_version=unknown in output"
+fi
+
+if echo "$result" | grep -q "presets_version=unknown"; then
+  pass "fallback: presets_version=unknown printed"
+else
+  fail "fallback: expected presets_version=unknown in output"
 fi
 
 # ============================================================
@@ -670,7 +682,9 @@ echo ""
 echo "Test 19: Drift + --strict + no resource_changes (refresh-only alarm)..."
 
 rm -rf "$WORKDIR/outputs"
-result="$(run_drift_check "$refresh_only_plan" --strict)"
+# Seed provenance env vars so we can pin that --strict mode still emits them.
+result="$(TEMPLATE_VERSION="v-strict-t" PRESETS_VERSION="v-strict-p" \
+  run_drift_check "$refresh_only_plan" --strict)"
 exit_code="$(echo "$result" | tail -1)"
 
 if [[ "$exit_code" -eq 2 ]]; then
@@ -693,6 +707,17 @@ if jq -e '.actionable == false' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; t
   pass "strict refresh-only: actionable stays false (strict ≠ actionable)"
 else
   fail "strict refresh-only: actionable should be false (no resource_changes)"
+fi
+
+# Pin the invariant that provenance fields survive the --strict exit path
+# (drift-refresh.sh depends on this for its standalone-alarm workflow).
+# A refactor that moved the strict exit above the jq block would drop
+# provenance silently; this assertion catches that.
+if jq -e '.template_version == "v-strict-t" and .presets_version == "v-strict-p"' \
+   "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "strict refresh-only: drift.json carries template_version + presets_version"
+else
+  fail "strict refresh-only: drift.json missing provenance fields"
 fi
 
 # ============================================================
@@ -882,6 +907,68 @@ if jq -e '.actionable == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; th
   pass "mixed-actions: actionable is true (at least one non-no-op/read)"
 else
   fail "mixed-actions: actionable should be true with any actionable entry"
+fi
+
+# ============================================================
+# Test 29: drift.json includes template_version and presets_version
+# provenance fields (sourced from env vars exported by parent).
+# ============================================================
+echo ""
+echo "Test 29: drift.json provenance fields..."
+
+provenance_plan='{
+  "resource_drift": [{"address": "aws_s3_bucket.example", "type": "aws_s3_bucket"}],
+  "resource_changes": [{"address": "aws_s3_bucket.example", "change": {"actions": ["update"]}}]
+}'
+
+# Both env vars set.
+rm -rf "$WORKDIR/outputs"
+TEMPLATE_VERSION="deadbeef" PRESETS_VERSION="v1.4.2" \
+  run_drift_check "$provenance_plan" >/dev/null || true
+
+if jq -e '.template_version == "deadbeef"' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift.json: template_version field populated"
+else
+  fail "drift.json: expected template_version=\"deadbeef\""
+fi
+
+if jq -e '.presets_version == "v1.4.2"' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift.json: presets_version field populated"
+else
+  fail "drift.json: expected presets_version=\"v1.4.2\""
+fi
+
+# Neither env var set — both fields should be JSON null (distinct from absent).
+rm -rf "$WORKDIR/outputs"
+(
+  unset TEMPLATE_VERSION PRESETS_VERSION
+  run_drift_check "$provenance_plan" >/dev/null || true
+)
+
+if jq -e '.template_version == null' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift.json: template_version null when env unset"
+else
+  fail "drift.json: template_version should be null when env unset"
+fi
+
+if jq -e '.presets_version == null' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift.json: presets_version null when env unset"
+else
+  fail "drift.json: presets_version should be null when env unset"
+fi
+
+# Only one set — the other stays null.
+rm -rf "$WORKDIR/outputs"
+(
+  unset PRESETS_VERSION
+  TEMPLATE_VERSION="only-template" run_drift_check "$provenance_plan" >/dev/null || true
+)
+
+if jq -e '.template_version == "only-template" and .presets_version == null' \
+   "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift.json: independent null-handling for each provenance field"
+else
+  fail "drift.json: expected template_version=\"only-template\" with presets_version=null"
 fi
 
 # --- Summary ---

--- a/tests/test-template-version.sh
+++ b/tests/test-template-version.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Tests for logTemplateVersion() and exportTemplateVersion() in shell_utils.sh.
+# Tests for logTemplateVersion(), exportTemplateVersion(), logPresetsVersion(),
+# and exportPresetsVersion() in shell_utils.sh.
 
 PASS=0
 FAIL=0
@@ -182,6 +183,183 @@ if [[ "$child_sees" == "NOTSET" ]]; then
   pass "logTemplateVersion: does not export (child sees NOTSET)"
 else
   fail "logTemplateVersion: unexpectedly exported TEMPLATE_VERSION; child saw '$child_sees'"
+fi
+
+# ============================================================
+# Presets_ref helpers mirror the template_ref helpers exactly.
+# ============================================================
+
+run_log_presets() {
+  (
+    export MARS_PROJECT_ROOT="$PROJECT"
+    # shellcheck disable=SC1091
+    . "$PROJECT/shell_utils.sh"
+    logPresetsVersion
+  )
+}
+
+set_presets_ref() {
+  local val="$1"
+  cat > "$PROJECT/tf/auto-vars/common.auto.tfvars.json" <<EOF
+{"presets_ref": "$val"}
+EOF
+}
+
+# ============================================================
+# Test 8: No presets_ref in tfvars → outputs "unknown"
+# ============================================================
+echo "Test 8: Missing presets_ref in tfvars..."
+
+echo '{}' > "$PROJECT/tf/auto-vars/common.auto.tfvars.json"
+output="$(run_log_presets)"
+
+if [[ "$output" == "presets_version=unknown" ]]; then
+  pass "missing key: outputs presets_version=unknown"
+else
+  fail "missing key: expected 'presets_version=unknown', got '$output'"
+fi
+
+# ============================================================
+# Test 9: presets_ref with a normal value
+# ============================================================
+echo "Test 9: Normal presets_ref value..."
+
+set_presets_ref "v1.4.2"
+output="$(run_log_presets)"
+
+if [[ "$output" == "presets_version=v1.4.2" ]]; then
+  pass "normal value: outputs correct presets version"
+else
+  fail "normal value: expected 'presets_version=v1.4.2', got '$output'"
+fi
+
+# ============================================================
+# Test 10: presets_ref JSON null → outputs "unknown"
+# ============================================================
+echo "Test 10: JSON null presets_ref value..."
+
+cat > "$PROJECT/tf/auto-vars/common.auto.tfvars.json" <<'EOF'
+{"presets_ref": null}
+EOF
+output="$(run_log_presets)"
+
+if [[ "$output" == "presets_version=unknown" ]]; then
+  pass "null value: outputs presets_version=unknown"
+else
+  fail "null value: expected 'presets_version=unknown', got '$output'"
+fi
+
+# ============================================================
+# Test 11: presets_ref empty string → outputs "unknown"
+# ============================================================
+echo "Test 11: Empty presets_ref value..."
+
+set_presets_ref ""
+output="$(run_log_presets)"
+
+if [[ "$output" == "presets_version=unknown" ]]; then
+  pass "empty value: outputs presets_version=unknown"
+else
+  fail "empty value: expected 'presets_version=unknown', got '$output'"
+fi
+
+# ============================================================
+# Test 12: exportPresetsVersion logs AND exports PRESETS_VERSION
+# ============================================================
+echo "Test 12: exportPresetsVersion exports env var..."
+
+set_presets_ref "v9.9.9"
+
+child_sees="$(
+  export MARS_PROJECT_ROOT="$PROJECT"
+  # shellcheck disable=SC1091
+  . "$PROJECT/shell_utils.sh"
+  exportPresetsVersion >/dev/null
+  bash -c 'echo "${PRESETS_VERSION:-NOTSET}"'
+)"
+
+if [[ "$child_sees" == "v9.9.9" ]]; then
+  pass "export: child process sees PRESETS_VERSION=v9.9.9"
+else
+  fail "export: expected child to see 'v9.9.9', got '$child_sees'"
+fi
+
+log_output="$(
+  export MARS_PROJECT_ROOT="$PROJECT"
+  # shellcheck disable=SC1091
+  . "$PROJECT/shell_utils.sh"
+  exportPresetsVersion
+)"
+
+if [[ "$log_output" == "presets_version=v9.9.9" ]]; then
+  pass "export: log line matches presets_version=v9.9.9"
+else
+  fail "export: expected log 'presets_version=v9.9.9', got '$log_output'"
+fi
+
+# ============================================================
+# Test 13: exportPresetsVersion falls back to unknown when missing
+# ============================================================
+echo "Test 13: exportPresetsVersion falls back to unknown..."
+
+echo '{}' > "$PROJECT/tf/auto-vars/common.auto.tfvars.json"
+
+log_output="$(
+  export MARS_PROJECT_ROOT="$PROJECT"
+  # shellcheck disable=SC1091
+  . "$PROJECT/shell_utils.sh"
+  exportPresetsVersion
+)"
+
+if [[ "$log_output" == "presets_version=unknown" ]]; then
+  pass "export fallback: logs presets_version=unknown"
+else
+  fail "export fallback: expected 'presets_version=unknown', got '$log_output'"
+fi
+
+# ============================================================
+# Test 14: logPresetsVersion does NOT export PRESETS_VERSION
+# ============================================================
+echo "Test 14: logPresetsVersion does not export..."
+
+set_presets_ref "should-not-leak"
+
+child_sees="$(
+  export MARS_PROJECT_ROOT="$PROJECT"
+  unset PRESETS_VERSION
+  # shellcheck disable=SC1091
+  . "$PROJECT/shell_utils.sh"
+  logPresetsVersion >/dev/null
+  bash -c 'echo "${PRESETS_VERSION:-NOTSET}"'
+)"
+
+if [[ "$child_sees" == "NOTSET" ]]; then
+  pass "logPresetsVersion: does not export (child sees NOTSET)"
+else
+  fail "logPresetsVersion: unexpectedly exported PRESETS_VERSION; child saw '$child_sees'"
+fi
+
+# ============================================================
+# Test 15: Both template_ref and presets_ref set → both log correctly
+# ============================================================
+echo "Test 15: Both refs set independently..."
+
+cat > "$PROJECT/tf/auto-vars/common.auto.tfvars.json" <<'EOF'
+{"template_ref": "deadbeef", "presets_ref": "v1.4.2"}
+EOF
+
+combined="$(
+  export MARS_PROJECT_ROOT="$PROJECT"
+  # shellcheck disable=SC1091
+  . "$PROJECT/shell_utils.sh"
+  logTemplateVersion
+  logPresetsVersion
+)"
+
+if [[ "$combined" == *"template_version=deadbeef"* && "$combined" == *"presets_version=v1.4.2"* ]]; then
+  pass "combined: both versions logged with correct values"
+else
+  fail "combined: expected both versions, got: $combined"
 fi
 
 # --- Summary ---

--- a/tf/apply-plan.sh
+++ b/tf/apply-plan.sh
@@ -54,6 +54,7 @@ export MARS_PROJECT_ROOT
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 exportTemplateVersion
+exportPresetsVersion
 
 # Source utils.sh (expects $1 = workspace/lifecycle)
 set -- "$lifecycle"
@@ -95,9 +96,21 @@ captureOutputs() {
 
 captureOutputs
 
-# Write empty drift.json stub if not already present so Argo doesn't
-# warn about a missing optional artifact.
+# Write drift.json stub if drift-check didn't produce one (not invoked, or
+# invoked but no drift). Mirrors the full drift-check.sh schema so consumers
+# get the same shape regardless of whether drift occurred, including the
+# template_version / presets_version provenance fields.
 if [ ! -f "$MARS_PROJECT_ROOT/outputs/drift.json" ]; then
   mkdir -p "$MARS_PROJECT_ROOT/outputs"
-  echo '{}' > "$MARS_PROJECT_ROOT/outputs/drift.json"
+  jq -n \
+    --arg tmpl "${TEMPLATE_VERSION:-}" \
+    --arg pres "${PRESETS_VERSION:-}" \
+    '{
+      drift_detected: false,
+      drift_count: 0,
+      actionable: false,
+      template_version: (if $tmpl == "" then null else $tmpl end),
+      presets_version: (if $pres == "" then null else $pres end),
+      resources: []
+    }' > "$MARS_PROJECT_ROOT/outputs/drift.json"
 fi

--- a/tf/apply-with-outputs.sh
+++ b/tf/apply-with-outputs.sh
@@ -45,6 +45,7 @@ export MARS_PROJECT_ROOT
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 exportTemplateVersion
+exportPresetsVersion
 
 captureOutputs() {
   mkdir -p "$MARS_PROJECT_ROOT/outputs"
@@ -93,9 +94,21 @@ else
   captureOutputs
 fi
 
-# Write empty drift.json stub if not already present so Argo doesn't
-# warn about a missing optional artifact.
+# Write drift.json stub if drift-check didn't produce one (not invoked, or
+# invoked but no drift). Mirrors the full drift-check.sh schema so consumers
+# get the same shape regardless of whether drift occurred, including the
+# template_version / presets_version provenance fields.
 if [ ! -f "$MARS_PROJECT_ROOT/outputs/drift.json" ]; then
   mkdir -p "$MARS_PROJECT_ROOT/outputs"
-  echo '{}' > "$MARS_PROJECT_ROOT/outputs/drift.json"
+  jq -n \
+    --arg tmpl "${TEMPLATE_VERSION:-}" \
+    --arg pres "${PRESETS_VERSION:-}" \
+    '{
+      drift_detected: false,
+      drift_count: 0,
+      actionable: false,
+      template_version: (if $tmpl == "" then null else $tmpl end),
+      presets_version: (if $pres == "" then null else $pres end),
+      resources: []
+    }' > "$MARS_PROJECT_ROOT/outputs/drift.json"
 fi

--- a/tf/apply.sh
+++ b/tf/apply.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 . ./utils.sh
 logTemplateVersion
+logPresetsVersion
 
 gitMergeInfraMain
 tfInit

--- a/tf/destroy.sh
+++ b/tf/destroy.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 . ./utils.sh
 logTemplateVersion
+logPresetsVersion
 
 tfInit
 tfDestroy

--- a/tf/drift-check.sh
+++ b/tf/drift-check.sh
@@ -61,6 +61,7 @@ fi
 : "${MARS_PROJECT_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 export MARS_PROJECT_ROOT
 echo "template_version=${TEMPLATE_VERSION:-unknown}"
+echo "presets_version=${PRESETS_VERSION:-unknown}"
 
 OUTPUTS_DIR="$MARS_PROJECT_ROOT/outputs"
 
@@ -156,7 +157,16 @@ _drift_report="$(jq -n \
   --argjson drift "$drift" \
   --argjson count "$drift_count" \
   --argjson changes "$has_plan_changes" \
-  '{ drift_detected: true, drift_count: $count, actionable: ($changes > 0), resources: $drift }')"
+  --arg tmpl "${TEMPLATE_VERSION:-}" \
+  --arg pres "${PRESETS_VERSION:-}" \
+  '{
+    drift_detected: true,
+    drift_count: $count,
+    actionable: ($changes > 0),
+    template_version: (if $tmpl == "" then null else $tmpl end),
+    presets_version: (if $pres == "" then null else $pres end),
+    resources: $drift
+  }')"
 
 # Always write drift.json (Argo artifact path expects this)
 echo "$_drift_report" > "$OUTPUTS_DIR/drift.json"

--- a/tf/drift-refresh.sh
+++ b/tf/drift-refresh.sh
@@ -27,6 +27,7 @@ export MARS_PROJECT_ROOT
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 exportTemplateVersion
+exportPresetsVersion
 
 # Source utils.sh (expects $1 = workspace/lifecycle)
 set -- "$lifecycle"

--- a/tf/plan-all.sh
+++ b/tf/plan-all.sh
@@ -23,6 +23,7 @@ export MARS_PROJECT_ROOT
 
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 logTemplateVersion
+logPresetsVersion
 
 STAGES="${PLAN_STAGES:-cloud-provision custom-stack-provision}"
 OUTPUTS_DIR="$MARS_PROJECT_ROOT/outputs"

--- a/tf/plan.sh
+++ b/tf/plan.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$MARS_PROJECT_ROOT/shell_utils.sh"
 . ./utils.sh
 logTemplateVersion
+logPresetsVersion
 
 tfInit
 tfPlan


### PR DESCRIPTION
## Summary

- Mirrors the existing `template_ref` → `template_version` provenance plumbing for `presets_ref`, landed upstream in [insideout-terraform-presets#108](https://github.com/luthersystems/insideout-terraform-presets/pull/108). Adds `logPresetsVersion` / `exportPresetsVersion` helpers in `shell_utils.sh`, wires them into the 9 scripts that already call the template pair, and emits a parallel `presets_version=<ref>` stdout line from `drift-check.sh`.
- Extends `drift.json` with `template_version` and `presets_version` fields (null when env-unset). Consumers (UI / Oracle) can now self-identify a drift report without log-scraping. **Schema change — strict consumers should be flagged before merge.**
- Replaces the `echo '{}'` stub in `tf/apply-with-outputs.sh` and `tf/apply-plan.sh` with a full-schema stub (`drift_detected: false`, `actionable: false`, provenance, empty resources). `drift.json` now has the same shape regardless of whether drift occurred.

## Caveat (tracked separately)

Per PR #108, the composer bakes `presets_ref` as the `default =` inside the generated `variables.tf`, not into `common.auto.tfvars.json`. `getTfVar` only scans auto-vars, so `getTfVar presets_ref` returns empty until [luthersystems/ui-core#296](https://github.com/luthersystems/ui-core/issues/296) lands. Until then, logs show `presets_version=unknown` and `drift.json` has `presets_version: null`. Plumbing is live the moment ui-core writes the field.

## Test plan

- [x] `tests/test-template-version.sh` — 17/17 (added 10 cases mirroring `template_ref` coverage).
- [x] `tests/test-drift-check.sh` — 85/85 (added Test 29 for drift.json provenance fields; extended Test 19 to pin that `--strict` mode carries provenance through to `drift.json`).
- [x] `tests/test-apply-scripts.sh` — 55/55 (added no-drift stub-shape assertions in Test 2; added integration assertion that `drift.json` produced via `apply-with-outputs.sh --check-drift` contains both provenance fields).
- [x] `bash -n` on all 11 modified shell scripts — clean.
- [x] Manual `jq -n` smoke of the new drift-report schema.
- [ ] Manual deploy post-merge: confirm `presets_version=unknown` today, flips to real version once ui-core#296 lands.

Closes #97