### PR TITLE
chore: ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ secrets/
 .tmp/
 .template_version
 tf/auto-vars/skip_remote_state.auto.tfvars.json
+.claude/scheduled_tasks.lock
 
 # Generated at deploy time by _selectCloudFiles() from .tf.tmpl templates
 tf/*/providers-*.tf


### PR DESCRIPTION
## Summary

- Add `.claude/scheduled_tasks.lock` to `.gitignore`. Per-checkout runtime artifact left by the Claude Code scheduled-task runner; never belongs in the repo.

## Test plan

- [x] `git status` no longer shows `.claude/scheduled_tasks.lock` as untracked