### PR TITLE
fix(drift-check): gate on address-joined drift, not "any actionable change"

### DIFF
--- a/tests/test-apply-scripts.sh
+++ b/tests/test-apply-scripts.sh
@@ -583,10 +583,10 @@ else
   fail "noop-plan drift: terraform apply not called"
 fi
 
-if echo "$output" | grep -q "drift detected but plan has no actionable changes"; then
+if echo "$output" | grep -q "drift detected but no drifted resource is being applied"; then
   pass "noop-plan drift: INFO line printed"
 else
-  fail "noop-plan drift: expected INFO line about no actionable changes"
+  fail "noop-plan drift: expected INFO line about no drifted resource being applied"
 fi
 
 if [[ -f "$PROJECT/outputs/drift.json" ]] && jq -e '.actionable == false' "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then

--- a/tests/test-drift-check.sh
+++ b/tests/test-drift-check.sh
@@ -823,7 +823,7 @@ else
 fi
 
 # Confirm we did NOT hit the INFO branch (mutually exclusive with ignore-drift).
-if echo "$result" | grep -q "drift detected but plan has no actionable changes"; then
+if echo "$result" | grep -q "drift detected but no drifted resource is being applied"; then
   fail "strict + ignore-drift: INFO branch fired (should be WARNING)"
 else
   pass "strict + ignore-drift: INFO branch did NOT fire"
@@ -1077,6 +1077,74 @@ if jq -e '.actionable == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; th
   pass "real-drift-plus-unrelated: actionable is true (drifted address has update action)"
 else
   fail "real-drift-plus-unrelated: actionable should be true"
+fi
+
+# Mirror Test 30's invariance check: drift_count and resources are unfiltered
+# regardless of the actionable join. A regression that filtered resources down
+# to the actionable subset would corrupt the diagnostic surface.
+if jq -e '.drift_count == 1 and (.resources | length) == 1' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "real-drift-plus-unrelated: drift_count and resources preserve diagnostic content"
+else
+  fail "real-drift-plus-unrelated: drift_count/resources should reflect the unfiltered drift entry"
+fi
+
+# ============================================================
+# Test 32: Heterogeneous drift list — two drift entries, only one whose
+# address has an actionable resource_changes entry. Catches mutations
+# where the address-join filter handles N=1 lists but not N>1 (e.g. a
+# stray .[0] reduction, or an `all`-instead-of-`any` predicate). Without
+# this, mutating the jq filter to `[$drift[0]] | select(...) | length`
+# would survive Tests 30/31 because both have length-1 drift lists.
+# ============================================================
+echo ""
+echo "Test 32: Heterogeneous drift list (one no-op, one actionable)..."
+
+rm -rf "$WORKDIR/outputs"
+mixed_drift_plan='{
+  "resource_drift": [
+    {
+      "address": "module.gcp_firestore.google_firestore_database.database",
+      "type": "google_firestore_database",
+      "change": {
+        "before": {"etag": "old"},
+        "after":  {"etag": "new"}
+      }
+    },
+    {
+      "address": "module.gcp_iam.google_project_iam_member.binding",
+      "type": "google_project_iam_member",
+      "change": {
+        "before": {"member": "user:old@example.com"},
+        "after":  {"member": "user:tampered@example.com"}
+      }
+    }
+  ],
+  "resource_changes": [
+    {"address": "module.gcp_firestore.google_firestore_database.database", "change": {"actions": ["no-op"]}},
+    {"address": "module.gcp_iam.google_project_iam_member.binding",        "change": {"actions": ["update"]}}
+  ]
+}'
+result="$(run_drift_check "$mixed_drift_plan")"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 2 ]]; then
+  pass "heterogeneous-drift: exit code 2 (one drift entry is actionable)"
+else
+  fail "heterogeneous-drift: expected exit 2, got $exit_code"
+fi
+
+if jq -e '.actionable == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "heterogeneous-drift: actionable is true (the iam binding drift matches an update action)"
+else
+  fail "heterogeneous-drift: actionable should be true with one actionable drift in the list"
+fi
+
+# Both drift entries survive — drift_count/resources is unfiltered. A regression
+# that joined the filter into the resources output would shrink to length 1.
+if jq -e '.drift_count == 2 and (.resources | length) == 2' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "heterogeneous-drift: both drift entries preserved in report (unfiltered)"
+else
+  fail "heterogeneous-drift: drift_count should be 2 and resources length 2"
 fi
 
 # --- Summary ---

--- a/tests/test-drift-check.sh
+++ b/tests/test-drift-check.sh
@@ -575,10 +575,10 @@ else
   fail "noop-plan: expected exit 0, got $exit_code"
 fi
 
-if echo "$result" | grep -q "drift detected but plan has no actionable changes"; then
+if echo "$result" | grep -q "drift detected but no drifted resource is being applied"; then
   pass "noop-plan: INFO line printed"
 else
-  fail "noop-plan: expected INFO line about no actionable changes"
+  fail "noop-plan: expected INFO line about no drifted resource being applied"
 fi
 
 if [[ -f "$WORKDIR/outputs/drift.json" ]]; then
@@ -969,6 +969,114 @@ if jq -e '.template_version == "only-template" and .presets_version == null' \
   pass "drift.json: independent null-handling for each provenance field"
 else
   fail "drift.json: expected template_version=\"only-template\" with presets_version=null"
+fi
+
+# ============================================================
+# Test 30: Computed-attr drift on idle resource + actionable change on
+# UNRELATED resource — must NOT block (issue #102 / insideout#209).
+# Reproduces the canonical scenario: operator runs tfdeploy to add a new
+# component while existing resources have benign computed-attr drift
+# (firestore.etag, storage_bucket.updated, etc.). Pre-fix, has_plan_changes
+# > 0 because of the new component, so drift on the idle resource gated
+# the apply. Post-fix, the address-join filter sees that the drifted
+# resource is no-op and the actionable resource isn't drifted, so the
+# drift is correctly classified as informational.
+# ============================================================
+echo ""
+echo "Test 30: Drift on idle resource + actionable change elsewhere..."
+
+rm -rf "$WORKDIR/outputs"
+issue_209_plan='{
+  "resource_drift": [
+    {
+      "address": "module.gcp_firestore.google_firestore_database.database",
+      "type": "google_firestore_database",
+      "change": {
+        "before": {"etag": "IOOtxuGkl5QDMN34r+Gkl5QD"},
+        "after":  {"etag": "IK2w2PHFl5QDMIHQkeKkl5QD"}
+      }
+    }
+  ],
+  "resource_changes": [
+    {"address": "module.gcp_firestore.google_firestore_database.database", "change": {"actions": ["no-op"]}},
+    {"address": "module.gcp_new_component.google_storage_bucket.bucket",   "change": {"actions": ["create"]}}
+  ]
+}'
+result="$(run_drift_check "$issue_209_plan")"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "issue-209: exit code 0 (idle-resource drift not blocking)"
+else
+  fail "issue-209: expected exit 0, got $exit_code"
+fi
+
+if echo "$result" | grep -q "drift detected but no drifted resource is being applied"; then
+  pass "issue-209: INFO line fires"
+else
+  fail "issue-209: expected INFO line; got: $result"
+fi
+
+if [[ -f "$WORKDIR/outputs/drift.json" ]]; then
+  pass "issue-209: drift.json still written (diagnostic artifact)"
+else
+  fail "issue-209: drift.json not created"
+fi
+
+if jq -e '.actionable == false' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "issue-209: actionable is false (drifted resource is no-op in plan)"
+else
+  fail "issue-209: actionable should be false — drifted resource is not in actionable resource_changes"
+fi
+
+# Diagnostic content survives — drift_count + resources reflect the unfiltered
+# null-vs-empty drift. ui-core's "Detected && !Actionable → informational"
+# rendering depends on this.
+if jq -e '.drift_count == 1 and (.resources | length) == 1' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "issue-209: drift_count and resources preserve diagnostic content"
+else
+  fail "issue-209: drift_count/resources should still reflect the drift entry"
+fi
+
+# ============================================================
+# Test 31: Drift on resource + actionable change on SAME resource +
+# unrelated actionable change — must block. Mirror of #30 but with the
+# join hitting. Guards against an over-eager filter that drops drift on
+# resources Terraform plans to overwrite.
+# ============================================================
+echo ""
+echo "Test 31: Drift on resource that is also being applied (with unrelated change)..."
+
+rm -rf "$WORKDIR/outputs"
+real_drift_plan='{
+  "resource_drift": [
+    {
+      "address": "module.gcp_iam.google_project_iam_member.binding",
+      "type": "google_project_iam_member",
+      "change": {
+        "before": {"member": "user:old@example.com"},
+        "after":  {"member": "user:tampered@example.com"}
+      }
+    }
+  ],
+  "resource_changes": [
+    {"address": "module.gcp_iam.google_project_iam_member.binding",      "change": {"actions": ["update"]}},
+    {"address": "module.gcp_new_component.google_storage_bucket.bucket", "change": {"actions": ["create"]}}
+  ]
+}'
+result="$(run_drift_check "$real_drift_plan")"
+exit_code="$(echo "$result" | tail -1)"
+
+if [[ "$exit_code" -eq 2 ]]; then
+  pass "real-drift-plus-unrelated: exit code 2 (drifted resource will be overwritten)"
+else
+  fail "real-drift-plus-unrelated: expected exit 2, got $exit_code"
+fi
+
+if jq -e '.actionable == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "real-drift-plus-unrelated: actionable is true (drifted address has update action)"
+else
+  fail "real-drift-plus-unrelated: actionable should be true"
 fi
 
 # --- Summary ---

--- a/tf/drift-check.sh
+++ b/tf/drift-check.sh
@@ -6,14 +6,17 @@
 #
 # Exit codes:
 #   0 — No drift detected, drift ignored via --ignore-drift, or drift found but
-#       the plan has no actionable changes (all resource_changes are no-op/read)
-#       and --strict was not passed. Drift is still reported and drift.json is
-#       still written in all these cases.
+#       no drifted resource is in the plan's actionable set (resource_changes[]
+#       entry for that address is no-op/read/absent) and --strict was not
+#       passed. Drift is still reported and drift.json is still written in all
+#       these cases.
 #   1 — Error (missing plan file, jq failure, etc.)
-#   2 — Drift detected AND (--strict OR plan has actionable changes).
+#   2 — Drift detected on a resource the plan will modify (resource_changes[]
+#       entry has a non-no-op/read action), OR --strict and any drift exists.
 #
-# Refresh-only plans (from `terraform plan -refresh-only`) always have no
-# actionable changes, so drift-check is informational on them by default. Pass
+# Refresh-only plans (from `terraform plan -refresh-only`) have no
+# resource_changes at all, so by definition no drift can be address-joined to
+# an actionable change — drift-check is informational on them by default. Pass
 # --strict to alarm on any drift regardless — used by drift-refresh.sh as a
 # standalone manual-edit detector.
 #
@@ -106,18 +109,24 @@ if [[ "$drift_count" -eq 0 ]]; then
   exit 0
 fi
 
-# Count plan changes that terraform would actually apply. Equivalent to
-# `terraform plan -detailed-exitcode` exit 2 vs 0. Computed attributes show up
-# in resource_drift but not in resource_changes, so this filters the common
-# false-positive pattern of provider-populated attrs (inline_policy,
-# managed_policy_arns, association_id, latest_restorable_time, etc.).
-# Missing/null change.actions falls through the select and counts as
-# actionable (fail-safe toward blocking apply).
-has_plan_changes="$(echo "$plan_json" | jq '
-  [
+# Address-join: a drift entry counts as actionable iff the same resource has
+# a non-no-op/read action in resource_changes[]. Computed attributes show up
+# in resource_drift but their resource_changes entry is no-op (Terraform
+# isn't going to do anything), so the join correctly drops them. Common
+# offenders: google_firestore_database.{etag,earliest_version_time},
+# google_storage_bucket.updated, aws_iam_role.{inline_policy,managed_policy_arns},
+# aws_db_instance.latest_restorable_time. No per-attribute allowlist needed —
+# Terraform's own plan tells us which drift matters (issue #102).
+#
+# Missing/null change.actions on a matched address falls through the select
+# and counts as actionable (fail-safe toward blocking apply).
+actionable_drift_count="$(echo "$plan_json" | jq --argjson drift "$drift" '
+  ([
     (.resource_changes // [])[] |
-    select(.change.actions != ["no-op"] and .change.actions != ["read"])
-  ] | length
+    select(.change.actions != ["no-op"] and .change.actions != ["read"]) |
+    .address
+  ] | unique) as $actionable_addrs |
+  [$drift[] | select(.address as $a | $actionable_addrs | index($a))] | length
 ')"
 
 echo "Drift detected: $drift_count resource(s) have drifted."
@@ -145,24 +154,25 @@ _drift_filter="$_normalize"'
 '
 echo "$drift" | jq -r "$_drift_filter"
 
-# Write drift report. `actionable` mirrors the exit-code gate: true when
-# resource_changes[] has a non-no-op/read entry (plan would actually change
-# something). Consumers (ui-core Job.drift_actionable) use it to distinguish
-# "drift detected, apply ran" from "drift detected, apply blocked" without
-# cross-referencing job status. In --strict mode, actionable stays false when
-# resource_changes[] is empty — the field reflects plan content only, not the
-# alarm semantics of strict mode.
+# Write drift report. `actionable` is true when at least one drifted resource
+# also has an actionable (non-no-op/read) entry in resource_changes[] — i.e.
+# Terraform plans to overwrite a resource that has out-of-band changes. This
+# matches ui-core's documented DriftStatus semantics: "Computed-attribute
+# false positives surface in resource_drift but not in resource_changes" →
+# Detected=true, Actionable=false → informational notice, not blocking.
+# In --strict mode, actionable still reflects plan content only (Option 1
+# from #95); strict-mode alarm is conveyed via exit code, not this field.
 mkdir -p "$OUTPUTS_DIR"
 _drift_report="$(jq -n \
   --argjson drift "$drift" \
   --argjson count "$drift_count" \
-  --argjson changes "$has_plan_changes" \
+  --argjson actionable "$actionable_drift_count" \
   --arg tmpl "${TEMPLATE_VERSION:-}" \
   --arg pres "${PRESETS_VERSION:-}" \
   '{
     drift_detected: true,
     drift_count: $count,
-    actionable: ($changes > 0),
+    actionable: ($actionable > 0),
     template_version: (if $tmpl == "" then null else $tmpl end),
     presets_version: (if $pres == "" then null else $pres end),
     resources: $drift
@@ -183,8 +193,8 @@ if [[ "$ignore_drift" == "true" ]]; then
   exit 0
 fi
 
-if [[ "$strict" != "true" && "$has_plan_changes" -eq 0 ]]; then
-  echo "INFO: drift detected but plan has no actionable changes (0 to add/change/destroy); not blocking apply."
+if [[ "$strict" != "true" && "$actionable_drift_count" -eq 0 ]]; then
+  echo "INFO: drift detected but no drifted resource is being applied; not blocking apply."
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

A drift entry now blocks apply iff the same address has a non-no-op/read action in `resource_changes[]`. Previously `drift-check.sh` fired whenever drift existed AND the plan had any actionable change anywhere — so adding a new component to a session with benign computed-attribute drift on existing resources gated the apply, training operators to run with `--ignore-drift`.

The fix is structural: address-join `resource_drift[]` against the actionable subset of `resource_changes[]`. Terraform's own plan output is the source of truth — no per-attribute allowlist.

ui-core's `DriftStatus` already documented this intent:

> Computed-attribute false positives surface in resource_drift but not in resource_changes → Detected=true, Actionable=false → informational notice

`drift-check.sh` now actually implements that.

## Behavior matrix

| drift on R | resource_changes[R] | actionable elsewhere | Before | After |
|---|---|---|---|---|
| present | update | — | block | block ✓ same |
| present | no-op | none | exit 0 (informational) | exit 0 (informational) ✓ same |
| present | no-op | yes (R'.create) | **block** ❌ false positive | exit 0 (informational) ✓ |
| present | absent | none | exit 0 | exit 0 ✓ |
| present | absent | yes (R'.create) | **block** ❌ | exit 0 ✓ |

`--strict` and `--ignore-drift` semantics unchanged.

## What stayed the same

- `drift_count` and `resources` remain unfiltered (post null-vs-empty), so the diagnostic content survives. ui-core's "Detected && !Actionable → informational notice" rendering keeps working.
- All 85 existing drift-check tests still pass under the new logic.
- All 54 existing apply-scripts tests still pass.

## What changed

- `has_plan_changes` (count of any non-no-op anywhere) → `actionable_drift_count` (count of drift entries whose address has a non-no-op/read action).
- `actionable` field in drift.json now reflects address-joined count, matching ui-core's documented semantics.
- INFO line wording updated: "drift detected but no drifted resource is being applied" — accurate for both refresh-only and "drift on idle resources alongside other actionable changes" cases.
- 7 new test assertions across two test cases cover the canonical issue scenarios (Tests 30-31 in `test-drift-check.sh`).

## Test plan

- [x] `bash tests/test-drift-check.sh` — 92/92 pass.
- [x] `bash tests/test-apply-scripts.sh` — 55/55 pass.
- [x] `shellcheck tf/drift-check.sh` clean.
- [ ] End-to-end: re-run `tfdeploy(sandbox=false)` against `sess_v2_CC7nDMjcOlun` (or any session with computed-attr drift) **without** `--ignore-drift`. Apply gate should pass cleanly.

Closes #102
Refs luthersystems/insideout-terraform-presets#209