### PR TITLE
fix(cloud-provision,drift-check): protect inspector resources + enrich drift.json

### DIFF
--- a/tests/test-drift-check.sh
+++ b/tests/test-drift-check.sh
@@ -1147,6 +1147,204 @@ else
   fail "heterogeneous-drift: drift_count should be 2 and resources length 2"
 fi
 
+# ============================================================
+# Tests 33-38: Per-resource enrichment for downstream classifier (issue #105).
+# drift.json must surface, on each resources[] entry:
+#   - type, name (passed through from terraform's resource_drift schema)
+#   - action: []string (joined from resource_changes), null when not in plan
+#   - change.before / change.after (raw, NOT normalized — the consumer wants
+#     the same payload terraform show -json produced)
+# These let the Go classifier in luthersystems/insideout-terraform-presets
+# run per-attribute rules without re-parsing the plan.
+# ============================================================
+
+# ============================================================
+# Test 33: Per-resource action[] populated from resource_changes
+# ============================================================
+echo ""
+echo "Test 33: Per-resource action[] joined from resource_changes..."
+
+rm -rf "$WORKDIR/outputs"
+enrich_plan='{
+  "resource_drift": [
+    {
+      "address": "module.iam.aws_iam_role.inspector",
+      "type": "aws_iam_role",
+      "name": "inspector",
+      "change": {
+        "before": {"managed_policy_arns": []},
+        "after":  {"managed_policy_arns": ["arn:aws:iam::aws:policy/ReadOnlyAccess"]}
+      }
+    }
+  ],
+  "resource_changes": [
+    {"address": "module.iam.aws_iam_role.inspector", "change": {"actions": ["update"]}}
+  ]
+}'
+run_drift_check "$enrich_plan" >/dev/null || true
+
+if jq -e '.resources[0].action == ["update"]' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: action[] joined from resource_changes"
+else
+  fail "enrich: expected action=[\"update\"], got $(jq '.resources[0].action' "$WORKDIR/outputs/drift.json")"
+fi
+
+if jq -e '.resources[0].type == "aws_iam_role"' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: type passed through"
+else
+  fail "enrich: expected type=aws_iam_role"
+fi
+
+if jq -e '.resources[0].name == "inspector"' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: name passed through"
+else
+  fail "enrich: expected name=inspector"
+fi
+
+# change.before / change.after must echo terraform show -json verbatim
+# (NOT normalize_empty'd). Classifier wants the raw payload.
+if jq -e '.resources[0].change.before.managed_policy_arns == []' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: change.before passed through unmodified (raw [], not null)"
+else
+  fail "enrich: expected change.before.managed_policy_arns=[], got $(jq '.resources[0].change.before' "$WORKDIR/outputs/drift.json")"
+fi
+
+if jq -e '.resources[0].change.after.managed_policy_arns == ["arn:aws:iam::aws:policy/ReadOnlyAccess"]' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: change.after passed through unmodified"
+else
+  fail "enrich: change.after wrong"
+fi
+
+# ============================================================
+# Test 34: action is null when address isn't in resource_changes
+# (refresh-only plans, idle-resource drift detected by other plans).
+# ============================================================
+echo ""
+echo "Test 34: action is null when address absent from resource_changes..."
+
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$refresh_only_plan" --strict)"
+
+if jq -e '.resources[0].action == null' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: action=null for refresh-only (no resource_changes)"
+else
+  fail "enrich: expected action=null, got $(jq '.resources[0].action' "$WORKDIR/outputs/drift.json")"
+fi
+
+# ============================================================
+# Test 35: Phantom-computed case (firestore etag) — action=["no-op"],
+# preserved verbatim so the downstream classifier can map address+attr→rule.
+# ============================================================
+echo ""
+echo "Test 35: Phantom-computed (firestore etag) action=[\"no-op\"]..."
+
+rm -rf "$WORKDIR/outputs"
+phantom_plan='{
+  "resource_drift": [
+    {
+      "address": "module.gcp_firestore.google_firestore_database.database",
+      "type": "google_firestore_database",
+      "name": "database",
+      "change": {
+        "before": {"etag": "old-etag"},
+        "after":  {"etag": "new-etag"}
+      }
+    }
+  ],
+  "resource_changes": [
+    {"address": "module.gcp_firestore.google_firestore_database.database", "change": {"actions": ["no-op"]}}
+  ]
+}'
+run_drift_check "$phantom_plan" >/dev/null || true
+
+if jq -e '.resources[0].action == ["no-op"]' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: action=[\"no-op\"] preserved (classifier sees benign)"
+else
+  fail "enrich: expected action=[\"no-op\"]"
+fi
+
+if jq -e '.resources[0].change.before.etag == "old-etag"' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: phantom etag before passed through"
+else
+  fail "enrich: phantom etag before missing"
+fi
+
+# ============================================================
+# Test 36: Heterogeneous drift list — each entry independently joined.
+# Drift A is no-op, Drift B is update — entries must each carry their own
+# action[]. Guards against a regression where the join scopes globally
+# (single action shared across all entries).
+# ============================================================
+echo ""
+echo "Test 36: Heterogeneous drift — each entry joined independently..."
+
+rm -rf "$WORKDIR/outputs"
+run_drift_check "$mixed_drift_plan" >/dev/null || true
+
+if jq -e '
+  (.resources[] | select(.address == "module.gcp_firestore.google_firestore_database.database").action) == ["no-op"]
+  and
+  (.resources[] | select(.address == "module.gcp_iam.google_project_iam_member.binding").action) == ["update"]
+' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: heterogeneous drift carries per-entry action[]"
+else
+  fail "enrich: heterogeneous join wrong: $(jq '[.resources[] | {address, action}]' "$WORKDIR/outputs/drift.json")"
+fi
+
+# ============================================================
+# Test 37: Replace-style action ([create, delete] / [delete, create]) is
+# preserved as the original ordered array. Pinned because the classifier
+# distinguishes forward vs reverse replacement for some rules.
+# ============================================================
+echo ""
+echo "Test 37: Replace-style action arrays preserved verbatim..."
+
+rm -rf "$WORKDIR/outputs"
+replace_plan='{
+  "resource_drift": [
+    {"address": "aws_x.y", "type": "aws_x", "name": "y", "change": {"before": {"k": "a"}, "after": {"k": "b"}}}
+  ],
+  "resource_changes": [
+    {"address": "aws_x.y", "change": {"actions": ["create", "delete"]}}
+  ]
+}'
+run_drift_check "$replace_plan" >/dev/null || true
+
+if jq -e '.resources[0].action == ["create", "delete"]' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: replace-forward action order preserved"
+else
+  fail "enrich: replace-forward order wrong"
+fi
+
+# ============================================================
+# Test 38: Backwards-compat invariant — top-level fields and exit codes
+# unchanged by the enrichment. Pin actionable + drift_count + drift_detected
+# alongside the new resources[].action so an old consumer (ui-core
+# parseDriftReport) keeps working unchanged. This is the non-regression
+# heart of #105 — pure addition.
+# ============================================================
+echo ""
+echo "Test 38: Top-level schema unchanged by enrichment (backwards compat)..."
+
+rm -rf "$WORKDIR/outputs"
+run_drift_check "$enrich_plan" >/dev/null || true
+
+if jq -e '
+  .drift_detected == true and
+  .drift_count == 1 and
+  .actionable == true and
+  (.resources | length) == 1 and
+  (.resources[0] | has("action")) and
+  (.resources[0] | has("type")) and
+  (.resources[0] | has("name")) and
+  (.resources[0].change | has("before")) and
+  (.resources[0].change | has("after"))
+' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "enrich: top-level + per-resource fields all present (additive)"
+else
+  fail "enrich: schema invariant violated: $(jq '.' "$WORKDIR/outputs/drift.json")"
+fi
+
 # --- Summary ---
 echo ""
 echo "================================"

--- a/tf/cloud-provision/aws-resources.tf.tmpl
+++ b/tf/cloud-provision/aws-resources.tf.tmpl
@@ -85,8 +85,12 @@ resource "aws_iam_role" "insideout_inspector" {
     Purpose   = "insideout-inspection"
   }
 
+  # AWS doesn't soft-delete IAM roles like GCP does service accounts, but a
+  # delete-then-create cycle still breaks any STS session/oracle path that
+  # cached the role ARN/path. Mirror the GCP guard for consistency. See #106.
   lifecycle {
-    ignore_changes = [managed_policy_arns]
+    ignore_changes  = [managed_policy_arns]
+    prevent_destroy = true
   }
 }
 

--- a/tf/cloud-provision/gcp-resources.tf.tmpl
+++ b/tf/cloud-provision/gcp-resources.tf.tmpl
@@ -53,41 +53,73 @@ locals {
   gcp_management_sa_id_out = google_service_account.insideout_management.account_id
 }
 
+# GCP soft-deletes service accounts with a 30-day retention window. If
+# Terraform ever issues delete-then-create on these resources (e.g. a future
+# display_name change, taint, or operator-driven `terraform destroy`), the
+# create fails because the email is reserved by the soft-deleted SA. Recovery
+# requires `gcloud iam service-accounts undelete <unique-id>`, which the
+# template-driven workflow does not perform. prevent_destroy fails the plan
+# loudly instead of silently leaving the project unrecoverable for 30 days.
+# See issues #104, #106.
 resource "google_service_account" "insideout_inspector" {
   account_id   = local.gcp_inspector_sa_id
   display_name = "InsideOut Inspector - ${var.project_id}"
   description  = "Read-only service account for InsideOut infrastructure inspection"
   project      = var.gcp_project_id
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_project_iam_member" "inspector_viewer" {
   project = var.gcp_project_id
   role    = "roles/viewer"
   member  = "serviceAccount:${google_service_account.insideout_inspector.email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_project_iam_member" "inspector_storage_viewer" {
   project = var.gcp_project_id
   role    = "roles/storage.objectViewer"
   member  = "serviceAccount:${google_service_account.insideout_inspector.email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_project_iam_member" "inspector_secretmanager_viewer" {
   project = var.gcp_project_id
   role    = "roles/secretmanager.viewer"
   member  = "serviceAccount:${google_service_account.insideout_inspector.email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_project_iam_member" "inspector_run_viewer" {
   project = var.gcp_project_id
   role    = "roles/run.viewer"
   member  = "serviceAccount:${google_service_account.insideout_inspector.email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_service_account_iam_member" "inspector_token_creator" {
   service_account_id = google_service_account.insideout_inspector.name
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${local.gcp_deployment_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_service_account" "insideout_management" {
@@ -95,18 +127,30 @@ resource "google_service_account" "insideout_management" {
   display_name = "InsideOut Management - ${var.project_id}"
   description  = "Project-scoped management service account for impersonated InsideOut Terraform operations"
   project      = var.gcp_project_id
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_project_iam_member" "management_owner" {
   project = var.gcp_project_id
   role    = "roles/owner"
   member  = "serviceAccount:${google_service_account.insideout_management.email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_service_account_iam_member" "management_token_creator" {
   service_account_id = google_service_account.insideout_management.name
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${local.gcp_deployment_sa_email}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # ============================================================================

--- a/tf/drift-check.sh
+++ b/tf/drift-check.sh
@@ -129,6 +129,25 @@ actionable_drift_count="$(echo "$plan_json" | jq --argjson drift "$drift" '
   [$drift[] | select(.address as $a | $actionable_addrs | index($a))] | length
 ')"
 
+# Enrich each drift entry with the joined action[] from resource_changes
+# (issue #105). The downstream classifier in luthersystems/insideout-terraform-presets
+# uses this — plus type, name, change.before, and change.after (all passed
+# through unmodified from terraform show -json) — to apply per-attribute
+# rules (phantom-computed, provider-noise, reconverge, actionable). action
+# is null when the address isn't in resource_changes[] (refresh-only plans
+# and addresses Terraform isn't touching). Independent of the actionable
+# rollup above so this enrichment can never regress the fail-safe gate
+# semantics — a future spec change to the action field need not move the
+# gate, and vice versa.
+addr_to_actions="$(echo "$plan_json" | jq '
+  reduce ((.resource_changes // [])[]) as $rc ({};
+    .[$rc.address] = ($rc.change.actions // null)
+  )
+')"
+drift="$(echo "$drift" | jq --argjson actions_map "$addr_to_actions" '
+  map(. + {action: ($actions_map[.address] // null)})
+')"
+
 echo "Drift detected: $drift_count resource(s) have drifted."
 echo ""
 


### PR DESCRIPTION
## Summary

Bundles three issues into one PR:

- **#104 / #106** — add `lifecycle.prevent_destroy = true` to the inspector and management service accounts and all their IAM bindings in `tf/cloud-provision/gcp-resources.tf.tmpl`, plus `aws_iam_role.insideout_inspector` in `aws-resources.tf.tmpl`. Stops Terraform from ever issuing delete-then-create on these resources, which would otherwise fail (GCP soft-deletes service accounts for 30 days, reserving the email) and leave the project unrecoverable from the workflow without manual `gcloud iam service-accounts undelete`.
- **#105** — enrich `drift.json` with per-resource `action[]` (address-joined from `resource_changes[]`), plus `type`, `name`, and raw `change.before` / `change.after` (already passed through unmodified from `terraform show -json`). Pure addition — old consumers (ui-core's `parseDriftReport`) see extra fields and ignore them; the top-level `actionable` rollup and exit semantics are unchanged.

The action enrichment is computed **independently** of the actionable rollup so the fail-safe gate semantics (missing `change.actions` on a matched address → counted as actionable) cannot be regressed by a future spec change to the action field. Both jq passes hit `$plan_json` directly.

## Why this is one PR

#104 is a diagnosis ticket; its concrete remediation in this repo is the prevent_destroy work in #106. #105 enriches `drift.json` for the downstream classifier (presets#219, reliable#1251) and lands cleanly in the same drift-check.sh that was just touched in #103. Bundling avoids three round-trip CI runs for tightly related cloud-provision / drift-check changes.

The lessons.md update mentioned in #104 lives in the `reliable*` repos, not this one — out of scope here.

## Test plan

- [x] `bash -n` clean on `tf/drift-check.sh` and `tests/test-drift-check.sh`
- [x] `terraform fmt -check` clean on the modified `.tmpl` files (validated via .tf copies)
- [x] `bash tests/test-drift-check.sh` — 107 tests pass (96 pre-existing + 11 new)
  - Per-resource `action[]` populated from `resource_changes[]` join
  - `action == null` when address absent from `resource_changes` (refresh-only plans)
  - Phantom-computed cases (firestore etag) preserve `action == ["no-op"]`
  - Heterogeneous drift list joins each entry independently
  - Replace-style action arrays (`["create","delete"]`) preserved verbatim
  - Top-level schema invariant: `drift_detected` / `drift_count` / `actionable` unchanged
  - Existing fail-safe gate semantics regression-tested (Test 27 — missing `change.actions`)
- [ ] Once merged, validate the new `drift.json` schema against the consumer in luthersystems/insideout-terraform-presets#219

## Related

- presets companion: luthersystems/insideout-terraform-presets#219
- reliable companion: luthersystems/reliable#1251
- prior art (this repo): #102 (address-join rationale) → #103 (just merged)

Closes #104
Closes #105
Closes #106