### PR TITLE
fix(drift-check): stop gating apply at the pod; move skip decision into wrappers

### DIFF
--- a/tests/test-apply-scripts.sh
+++ b/tests/test-apply-scripts.sh
@@ -256,6 +256,12 @@ else
   fail "drift-check mode: stub drift.json missing actionable=false"
 fi
 
+if jq -e '.apply_skipped == false' "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift-check mode: stub drift.json has apply_skipped=false (no drift, apply ran)"
+else
+  fail "drift-check mode: stub drift.json missing apply_skipped=false"
+fi
+
 if jq -e '.template_version == null and .presets_version == null' \
    "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then
   pass "drift-check mode: stub drift.json has null provenance fields (env unset)"
@@ -269,9 +275,10 @@ else
   fail "drift-check mode: stub drift.json resources field wrong"
 fi
 
-# --- Test 3: Drift-check mode + drift detected → exit 2, apply not called ---
+# --- Test 3: Drift-check mode + drift detected → exit 0 (issue #108),
+# apply skipped via drift.json's apply_skipped flag, not exit code. ---
 echo ""
-echo "Test 3: Drift-check mode with drift..."
+echo "Test 3: Drift-check mode with actionable drift..."
 
 echo '{
   "resource_drift": [{"address": "aws_s3_bucket.test"}],
@@ -283,24 +290,36 @@ output="$(run_script apply-with-outputs.sh default --check-drift 2>&1)"
 exit_code=$?
 set -e
 
-if [[ "$exit_code" -eq 2 ]]; then
-  pass "drift detected: exit code 2"
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "drift detected: exit code 0 (pod no longer gates at exit-2)"
 else
-  fail "drift detected: expected exit 2, got $exit_code. Output: $output"
+  fail "drift detected: expected exit 0, got $exit_code. Output: $output"
 fi
 
-# terraform apply should NOT appear after drift-check exits 2
-# The apply line may exist from the plan step, check specifically for "apply -input=false apply.tfplan"
+# Apply must NOT run despite the exit-0 — wrapper reads drift.json and skips.
+# This is the core invariant of the new gate location.
 if grep -q "terraform apply -input=false apply.tfplan" "$CMD_LOG"; then
-  fail "drift detected: terraform apply should not run"
+  fail "drift detected: terraform apply should not run when apply_skipped:true"
 else
-  pass "drift detected: terraform apply not called (correct)"
+  pass "drift detected: terraform apply not called (wrapper honored apply_skipped)"
 fi
 
 if [[ -f "$PROJECT/outputs/drift-default.json" ]]; then
   pass "drift detected: drift-default.json created"
 else
   fail "drift detected: drift-default.json not created"
+fi
+
+if jq -e '.apply_skipped == true' "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift detected: drift.json has apply_skipped:true"
+else
+  fail "drift detected: expected apply_skipped:true in drift.json"
+fi
+
+if echo "$output" | grep -q "skipping terraform apply"; then
+  pass "drift detected: wrapper logged skip reason"
+else
+  fail "drift detected: expected 'skipping terraform apply' log; got: $output"
 fi
 
 # Reset show output
@@ -441,9 +460,10 @@ else
   fail "apply-plan drift-check: drift-check.sh not invoked"
 fi
 
-# --- Test 7: apply-plan with --check-drift + drift → exit 2 ---
+# --- Test 7: apply-plan with --check-drift + actionable drift →
+# exit 0 (issue #108), apply NOT called because apply_skipped:true. ---
 echo ""
-echo "Test 7: apply-plan with drift detected..."
+echo "Test 7: apply-plan with actionable drift detected..."
 
 echo '{
   "resource_drift": [{"address": "aws_vpc.main"}],
@@ -456,10 +476,56 @@ output="$(run_script apply-plan.sh default --plan-file myplan --check-drift 2>&1
 exit_code=$?
 set -e
 
-if [[ "$exit_code" -eq 2 ]]; then
-  pass "apply-plan drift: exit code 2"
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "apply-plan drift: exit code 0 (pod no longer gates at exit-2)"
 else
-  fail "apply-plan drift: expected exit 2, got $exit_code. Output: $output"
+  fail "apply-plan drift: expected exit 0, got $exit_code. Output: $output"
+fi
+
+if grep -q "terraform apply -input=false myplan.tfplan" "$CMD_LOG"; then
+  fail "apply-plan drift: terraform apply should not run when apply_skipped:true"
+else
+  pass "apply-plan drift: terraform apply not called (wrapper honored apply_skipped)"
+fi
+
+if jq -e '.apply_skipped == true' "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then
+  pass "apply-plan drift: drift.json has apply_skipped:true"
+else
+  fail "apply-plan drift: expected apply_skipped:true in drift.json"
+fi
+
+# --- Test 7b: apply-plan + --check-drift + --ignore-drift → exit 0,
+# apply runs (force-apply path used by reliable). ---
+echo ""
+echo "Test 7b: apply-plan with --check-drift --ignore-drift (force apply)..."
+
+echo '{
+  "resource_drift": [{"address": "aws_vpc.main"}],
+  "resource_changes": [{"address": "aws_vpc.main", "change": {"actions": ["update"]}}]
+}' > "$TF_SHOW_OUTPUT"
+echo "fake-plan" > "$PROJECT/tf/default/myplan.tfplan"
+
+set +e
+output="$(run_script apply-plan.sh default --plan-file myplan --check-drift --ignore-drift 2>&1)"
+exit_code=$?
+set -e
+
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "apply-plan force: exit code 0"
+else
+  fail "apply-plan force: expected exit 0, got $exit_code. Output: $output"
+fi
+
+if grep -q "terraform apply -input=false myplan.tfplan" "$CMD_LOG"; then
+  pass "apply-plan force: terraform apply called (force-apply through drift)"
+else
+  fail "apply-plan force: terraform apply should run with --ignore-drift"
+fi
+
+if jq -e '.apply_skipped == false' "$PROJECT/outputs/drift.json" >/dev/null 2>&1; then
+  pass "apply-plan force: drift.json has apply_skipped:false"
+else
+  fail "apply-plan force: expected apply_skipped:false with --ignore-drift"
 fi
 
 # Reset

--- a/tests/test-drift-check.sh
+++ b/tests/test-drift-check.sh
@@ -88,15 +88,16 @@ else
 fi
 
 # ============================================================
-# Test 2: Drift detected — exit 2, drift.json created
+# Test 2: Drift detected — exit 0 (issue #108), drift.json with
+# apply_skipped:true; the apply wrappers gate on that field, not exit code.
 # ============================================================
 echo ""
 echo "Test 2: Drift detected..."
 
 rm -rf "$WORKDIR/outputs"
-# drift_plan includes an actionable resource_changes entry so the plan-change
-# gate in drift-check.sh treats drift as apply-blocking (exit 2). Tests that
-# want to exercise the "drift but plan is no-op" gate use other fixtures below.
+# drift_plan includes an actionable resource_changes entry so the actionable
+# rollup in drift-check.sh sets apply_skipped:true. Tests that want to
+# exercise the "drift but plan is no-op" path use other fixtures below.
 drift_plan='{
   "resource_drift": [{"address": "aws_s3_bucket.example", "type": "aws_s3_bucket"}],
   "resource_changes": [{"address": "aws_s3_bucket.example", "change": {"actions": ["update"]}}]
@@ -104,10 +105,16 @@ drift_plan='{
 result="$(run_drift_check "$drift_plan")"
 exit_code="$(echo "$result" | tail -1)"
 
-if [[ "$exit_code" -eq 2 ]]; then
-  pass "drift: exit code 2"
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "drift: exit code 0 (pod no longer gates at exit-2)"
 else
-  fail "drift: expected exit 2, got $exit_code"
+  fail "drift: expected exit 0, got $exit_code"
+fi
+
+if jq -e '.apply_skipped == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "drift: apply_skipped is true (apply wrappers will skip)"
+else
+  fail "drift: apply_skipped should be true for actionable drift without --ignore-drift"
 fi
 
 if [[ -f "$WORKDIR/outputs/drift.json" ]]; then
@@ -179,6 +186,14 @@ if jq -e '.actionable == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; th
   pass "ignore-drift: actionable field preserved"
 else
   fail "ignore-drift: actionable field missing or wrong"
+fi
+
+# Force-apply path: --ignore-drift must flip apply_skipped to false so
+# the apply wrappers run terraform apply despite drift.
+if jq -e '.apply_skipped == false' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "ignore-drift: apply_skipped is false (force-apply path)"
+else
+  fail "ignore-drift: apply_skipped should be false when --ignore-drift is set"
 fi
 
 # ============================================================
@@ -279,10 +294,10 @@ rm -rf "$WORKDIR/outputs"
 result="$(run_drift_check "$drift_plan" --stage cloud-provision)"
 exit_code="$(echo "$result" | tail -1)"
 
-if [[ "$exit_code" -eq 2 ]]; then
-  pass "stage flag: exit code 2"
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "stage flag: exit code 0 (default no longer gates at exit-2)"
 else
-  fail "stage flag: expected exit 2, got $exit_code"
+  fail "stage flag: expected exit 0, got $exit_code"
 fi
 
 if [[ -f "$WORKDIR/outputs/drift-cloud-provision.json" ]]; then
@@ -360,10 +375,10 @@ rm -rf "$WORKDIR/outputs"
 result="$(run_drift_check "$drift_plan")"
 exit_code="$(echo "$result" | tail -1)"
 
-if [[ "$exit_code" -eq 2 ]]; then
-  pass "no stage: exit code 2 (drift detected)"
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "no stage: exit code 0 (drift detected, default no longer gates at exit-2)"
 else
-  fail "no stage: expected exit 2, got $exit_code"
+  fail "no stage: expected exit 0, got $exit_code"
 fi
 
 if [[ -f "$WORKDIR/outputs/drift.json" ]]; then
@@ -443,10 +458,10 @@ mixed_plan='{
 result="$(run_drift_check "$mixed_plan")"
 exit_code="$(echo "$result" | tail -1)"
 
-if [[ "$exit_code" -eq 2 ]]; then
-  pass "mixed: exit code 2 (real drift present)"
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "mixed: exit code 0 (real drift present, default no longer gates)"
 else
-  fail "mixed: expected exit 2, got $exit_code"
+  fail "mixed: expected exit 0, got $exit_code"
 fi
 
 if [[ -f "$WORKDIR/outputs/drift.json" ]]; then
@@ -465,6 +480,12 @@ if jq -e '.resources[0].address == "aws_instance.real_drift"' "$WORKDIR/outputs/
   pass "mixed: only real drift resource in report"
 else
   fail "mixed: expected aws_instance.real_drift in report"
+fi
+
+if jq -e '.apply_skipped == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "mixed: apply_skipped is true (real drift on actionable resource)"
+else
+  fail "mixed: apply_skipped should be true when real actionable drift present"
 fi
 
 # ============================================================
@@ -599,6 +620,12 @@ else
   fail "noop-plan: actionable should be false when plan has no actionable changes"
 fi
 
+if jq -e '.apply_skipped == false' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "noop-plan: apply_skipped is false (non-actionable drift, apply runs)"
+else
+  fail "noop-plan: apply_skipped should be false when actionable=false"
+fi
+
 # ============================================================
 # Test 17: Drift + resource_changes all "read" — exit 0
 # Data-source refreshes are not actionable.
@@ -640,6 +667,12 @@ else
   fail "read-only: actionable should be false for ['read']-only plans"
 fi
 
+if jq -e '.apply_skipped == false' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "read-only: apply_skipped is false (read-only plan, apply runs)"
+else
+  fail "read-only: apply_skipped should be false when actionable=false"
+fi
+
 # ============================================================
 # Test 18: Drift + resource_changes absent — exit 0
 # ============================================================
@@ -672,6 +705,12 @@ if jq -e '.actionable == false' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; t
   pass "refresh-only shape: actionable is false (no resource_changes)"
 else
   fail "refresh-only shape: actionable should be false"
+fi
+
+if jq -e '.apply_skipped == false' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "refresh-only shape: apply_skipped is false (no actionable changes)"
+else
+  fail "refresh-only shape: apply_skipped should be false when actionable=false"
 fi
 
 # ============================================================
@@ -831,8 +870,11 @@ fi
 
 # ============================================================
 # Tests 23-27: Action-kind coverage — every actionable action in
-# resource_changes[] must block apply. Guards against a mutation that
-# accidentally treats delete/create/replace as non-actionable.
+# resource_changes[] must mark drift as actionable + apply_skipped:true.
+# Guards against a mutation that accidentally treats delete/create/replace
+# as non-actionable. After issue #108 the gate moved from drift-check's
+# exit code (was exit 2) to drift.json's apply_skipped field, so the
+# assertion target is apply_skipped:true rather than exit 2.
 # ============================================================
 for action_case in \
   'delete|["delete"]' \
@@ -861,10 +903,10 @@ for action_case in \
   result="$(run_drift_check "$action_plan")"
   exit_code="$(echo "$result" | tail -1)"
 
-  if [[ "$exit_code" -eq 2 ]]; then
-    pass "action-kind $name: exit 2 (treated as actionable)"
+  if [[ "$exit_code" -eq 0 ]]; then
+    pass "action-kind $name: exit 0 (default no longer gates at exit-2)"
   else
-    fail "action-kind $name: expected exit 2, got $exit_code. Output: $result"
+    fail "action-kind $name: expected exit 0, got $exit_code. Output: $result"
   fi
 
   # Partial-match mutations (e.g. `select(.change.actions | contains(["create"]))`)
@@ -873,6 +915,12 @@ for action_case in \
     pass "action-kind $name: actionable is true"
   else
     fail "action-kind $name: actionable should be true"
+  fi
+
+  if jq -e '.apply_skipped == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+    pass "action-kind $name: apply_skipped is true (apply wrappers will skip)"
+  else
+    fail "action-kind $name: apply_skipped should be true for actionable drift"
   fi
 done
 
@@ -897,16 +945,22 @@ mixed_actions_plan='{
 result="$(run_drift_check "$mixed_actions_plan")"
 exit_code="$(echo "$result" | tail -1)"
 
-if [[ "$exit_code" -eq 2 ]]; then
-  pass "mixed-actions: exit code 2 (actionable entry present)"
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "mixed-actions: exit code 0 (default no longer gates at exit-2)"
 else
-  fail "mixed-actions: expected exit 2, got $exit_code"
+  fail "mixed-actions: expected exit 0, got $exit_code"
 fi
 
 if jq -e '.actionable == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
   pass "mixed-actions: actionable is true (at least one non-no-op/read)"
 else
   fail "mixed-actions: actionable should be true with any actionable entry"
+fi
+
+if jq -e '.apply_skipped == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "mixed-actions: apply_skipped is true (actionable drift on drifted resource)"
+else
+  fail "mixed-actions: apply_skipped should be true with any actionable entry"
 fi
 
 # ============================================================
@@ -1067,16 +1121,22 @@ real_drift_plan='{
 result="$(run_drift_check "$real_drift_plan")"
 exit_code="$(echo "$result" | tail -1)"
 
-if [[ "$exit_code" -eq 2 ]]; then
-  pass "real-drift-plus-unrelated: exit code 2 (drifted resource will be overwritten)"
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "real-drift-plus-unrelated: exit code 0 (default no longer gates at exit-2)"
 else
-  fail "real-drift-plus-unrelated: expected exit 2, got $exit_code"
+  fail "real-drift-plus-unrelated: expected exit 0, got $exit_code"
 fi
 
 if jq -e '.actionable == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
   pass "real-drift-plus-unrelated: actionable is true (drifted address has update action)"
 else
   fail "real-drift-plus-unrelated: actionable should be true"
+fi
+
+if jq -e '.apply_skipped == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "real-drift-plus-unrelated: apply_skipped is true (drifted resource will be overwritten)"
+else
+  fail "real-drift-plus-unrelated: apply_skipped should be true"
 fi
 
 # Mirror Test 30's invariance check: drift_count and resources are unfiltered
@@ -1127,16 +1187,22 @@ mixed_drift_plan='{
 result="$(run_drift_check "$mixed_drift_plan")"
 exit_code="$(echo "$result" | tail -1)"
 
-if [[ "$exit_code" -eq 2 ]]; then
-  pass "heterogeneous-drift: exit code 2 (one drift entry is actionable)"
+if [[ "$exit_code" -eq 0 ]]; then
+  pass "heterogeneous-drift: exit code 0 (default no longer gates at exit-2)"
 else
-  fail "heterogeneous-drift: expected exit 2, got $exit_code"
+  fail "heterogeneous-drift: expected exit 0, got $exit_code"
 fi
 
 if jq -e '.actionable == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
   pass "heterogeneous-drift: actionable is true (the iam binding drift matches an update action)"
 else
   fail "heterogeneous-drift: actionable should be true with one actionable drift in the list"
+fi
+
+if jq -e '.apply_skipped == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "heterogeneous-drift: apply_skipped is true (one drift entry is actionable)"
+else
+  fail "heterogeneous-drift: apply_skipped should be true with one actionable drift"
 fi
 
 # Both drift entries survive — drift_count/resources is unfiltered. A regression
@@ -1343,6 +1409,75 @@ if jq -e '
   pass "enrich: top-level + per-resource fields all present (additive)"
 else
   fail "enrich: schema invariant violated: $(jq '.' "$WORKDIR/outputs/drift.json")"
+fi
+
+# ============================================================
+# Test 39: Issue #108 invariant — pod no longer gates apply at exit-2.
+# Locks down the full exit-code-vs-apply_skipped matrix in one place so
+# any regression to the old "drift detected → exit 2" behavior fails
+# loudly. Independent of Tests 2/8/10/12/23-28/30-32 which exercise the
+# same field individually.
+# ============================================================
+echo ""
+echo "Test 39: Issue #108 — exit-code vs apply_skipped matrix..."
+
+actionable_plan='{
+  "resource_drift": [{"address": "aws_a.b", "change": {"before": {"k": "x"}, "after": {"k": "y"}}}],
+  "resource_changes": [{"address": "aws_a.b", "change": {"actions": ["update"]}}]
+}'
+
+# Row 1: actionable drift, no flag → exit 0 + apply_skipped:true (NEW)
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$actionable_plan")"
+exit_code="$(echo "$result" | tail -1)"
+if [[ "$exit_code" -eq 0 ]] && jq -e '.apply_skipped == true' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "issue-108 default: exit 0 + apply_skipped:true (pod doesn't gate, wrappers will)"
+else
+  fail "issue-108 default: expected exit 0 + apply_skipped:true; got exit=$exit_code skipped=$(jq '.apply_skipped' "$WORKDIR/outputs/drift.json" 2>&1)"
+fi
+
+# Row 2: actionable drift + --ignore-drift → exit 0 + apply_skipped:false (force)
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$actionable_plan" --ignore-drift)"
+exit_code="$(echo "$result" | tail -1)"
+if [[ "$exit_code" -eq 0 ]] && jq -e '.apply_skipped == false' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "issue-108 force: --ignore-drift sets apply_skipped:false (reliable's force-apply path)"
+else
+  fail "issue-108 force: expected exit 0 + apply_skipped:false; got exit=$exit_code skipped=$(jq '.apply_skipped' "$WORKDIR/outputs/drift.json" 2>&1)"
+fi
+
+# Row 3: drift on no-op plan, no flag → exit 0 + apply_skipped:false
+rm -rf "$WORKDIR/outputs"
+noop_drift_plan='{
+  "resource_drift": [{"address": "aws_a.b", "change": {"before": {"k": "x"}, "after": {"k": "y"}}}],
+  "resource_changes": [{"address": "aws_a.b", "change": {"actions": ["no-op"]}}]
+}'
+result="$(run_drift_check "$noop_drift_plan")"
+exit_code="$(echo "$result" | tail -1)"
+if [[ "$exit_code" -eq 0 ]] && jq -e '.apply_skipped == false' "$WORKDIR/outputs/drift.json" >/dev/null 2>&1; then
+  pass "issue-108 noop: non-actionable drift → apply_skipped:false (apply runs)"
+else
+  fail "issue-108 noop: expected exit 0 + apply_skipped:false; got exit=$exit_code skipped=$(jq '.apply_skipped' "$WORKDIR/outputs/drift.json" 2>&1)"
+fi
+
+# Row 4: actionable drift + --strict → exit 2 (refresh standalone alarm path)
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$actionable_plan" --strict)"
+exit_code="$(echo "$result" | tail -1)"
+if [[ "$exit_code" -eq 2 ]]; then
+  pass "issue-108 strict: actionable + --strict → exit 2 (standalone refresh alarm preserved)"
+else
+  fail "issue-108 strict: expected exit 2, got $exit_code"
+fi
+
+# Row 5: --ignore-drift WARNING log fires (reliable force-apply trace).
+# Tightens Test 22 by asserting the log on the default-mode path too.
+rm -rf "$WORKDIR/outputs"
+result="$(run_drift_check "$actionable_plan" --ignore-drift)"
+if echo "$result" | grep -q "WARNING: Drift ignored"; then
+  pass "issue-108 force log: WARNING line fires under --ignore-drift"
+else
+  fail "issue-108 force log: expected 'WARNING: Drift ignored' in output; got: $result"
 fi
 
 # --- Summary ---

--- a/tf/apply-plan.sh
+++ b/tf/apply-plan.sh
@@ -82,6 +82,16 @@ if [[ "$check_drift" == "true" ]]; then
     drift_args+=("--ignore-drift")
   fi
   bash "$SCRIPT_DIR/drift-check.sh" "$plan_file" --stage "$lifecycle" "${drift_args[@]+"${drift_args[@]}"}"
+
+  # Pod-level apply gate (issue #108). drift-check.sh writes apply_skipped
+  # into drift.json based on actionable drift + --ignore-drift. We honor it
+  # here so the gate lives in the pod, not in drift-check's exit code.
+  # Reliable's force-apply UX flips this to false via --ignore-drift.
+  apply_skipped="$(jq -r '.apply_skipped // false' "$MARS_PROJECT_ROOT/outputs/drift.json" 2>/dev/null || echo false)"
+  if [[ "$apply_skipped" == "true" ]]; then
+    echo "INFO: apply_skipped=true in drift.json; skipping terraform apply. Re-run with --ignore-drift to force."
+    exit 0
+  fi
 fi
 
 terraform apply -input=false "$plan_file"
@@ -109,6 +119,7 @@ if [ ! -f "$MARS_PROJECT_ROOT/outputs/drift.json" ]; then
       drift_detected: false,
       drift_count: 0,
       actionable: false,
+      apply_skipped: false,
       template_version: (if $tmpl == "" then null else $tmpl end),
       presets_version: (if $pres == "" then null else $pres end),
       resources: []

--- a/tf/apply-with-outputs.sh
+++ b/tf/apply-with-outputs.sh
@@ -69,12 +69,19 @@ if [[ "$check_drift" == "true" ]]; then
   terraform init -input=false
   terraform plan -out=apply.tfplan -input=false
 
-  # Check drift (may exit 2 if drift found and not ignored)
+  # Check drift. Drift-check exits 0 by default (issue #108) and writes
+  # apply_skipped into drift.json; we honor that here as the apply gate.
   drift_args=()
   if [[ "$ignore_drift" == "true" ]]; then
     drift_args+=("--ignore-drift")
   fi
   bash "$SCRIPT_DIR/drift-check.sh" apply.tfplan --stage "$lifecycle" "${drift_args[@]+"${drift_args[@]}"}"
+
+  apply_skipped="$(jq -r '.apply_skipped // false' "$MARS_PROJECT_ROOT/outputs/drift.json" 2>/dev/null || echo false)"
+  if [[ "$apply_skipped" == "true" ]]; then
+    echo "INFO: apply_skipped=true in drift.json; skipping terraform apply. Re-run with --ignore-drift to force."
+    exit 0
+  fi
 
   terraform apply -input=false apply.tfplan
   captureOutputs
@@ -107,6 +114,7 @@ if [ ! -f "$MARS_PROJECT_ROOT/outputs/drift.json" ]; then
       drift_detected: false,
       drift_count: 0,
       actionable: false,
+      apply_skipped: false,
       template_version: (if $tmpl == "" then null else $tmpl end),
       presets_version: (if $pres == "" then null else $pres end),
       resources: []

--- a/tf/drift-check.sh
+++ b/tf/drift-check.sh
@@ -5,23 +5,30 @@
 # Usage: bash drift-check.sh <plan-file> [--ignore-drift] [--stage <name>] [--strict]
 #
 # Exit codes:
-#   0 — No drift detected, drift ignored via --ignore-drift, or drift found but
-#       no drifted resource is in the plan's actionable set (resource_changes[]
-#       entry for that address is no-op/read/absent) and --strict was not
-#       passed. Drift is still reported and drift.json is still written in all
-#       these cases.
-#   1 — Error (missing plan file, jq failure, etc.)
-#   2 — Drift detected on a resource the plan will modify (resource_changes[]
-#       entry has a non-no-op/read action), OR --strict and any drift exists.
+#   0 — Default. No drift, OR drift detected (the pod no longer gates apply
+#       at exit-2 — see issue #108). The decision to skip apply on
+#       actionable drift is conveyed via `apply_skipped: true` in drift.json
+#       and is enforced by the apply wrappers (apply-plan.sh,
+#       apply-with-outputs.sh), which read drift.json and skip
+#       `terraform apply` when set. `reliable` + ui-core render the
+#       per-resource verdict from the same artifact.
+#   1 — Error (missing plan file, jq failure, etc.).
+#   2 — `--strict` and drift exists. Reserved for the standalone refresh
+#       alarm path (drift-refresh.sh as a manual-edit detector). Apply paths
+#       never see exit 2 unless they explicitly opt in to --strict.
+#
+# `--ignore-drift` is the force-apply override — used end-to-end by reliable
+# (UI → /api/tf/start?ignore_drift=true → Oracle workflow argv → here).
+# When set: log WARNING, write `apply_skipped: false`, exit 0 — apply runs.
 #
 # Refresh-only plans (from `terraform plan -refresh-only`) have no
-# resource_changes at all, so by definition no drift can be address-joined to
-# an actionable change — drift-check is informational on them by default. Pass
-# --strict to alarm on any drift regardless — used by drift-refresh.sh as a
-# standalone manual-edit detector.
+# resource_changes at all, so actionable_drift_count is always 0 and
+# apply_skipped is always false in their drift.json. The strict alarm
+# signal for those is exit 2, not the apply_skipped field.
 #
-# If drift is found, writes a JSON report to $MARS_PROJECT_ROOT/outputs/drift.json.
-# Does NOT source utils.sh — operates on a plan file already in the CWD.
+# Always writes a JSON report to $MARS_PROJECT_ROOT/outputs/drift.json when
+# drift is detected. Does NOT source utils.sh — operates on a plan file
+# already in the CWD.
 
 set -euo pipefail
 
@@ -173,25 +180,39 @@ _drift_filter="$_normalize"'
 '
 echo "$drift" | jq -r "$_drift_filter"
 
-# Write drift report. `actionable` is true when at least one drifted resource
-# also has an actionable (non-no-op/read) entry in resource_changes[] — i.e.
-# Terraform plans to overwrite a resource that has out-of-band changes. This
-# matches ui-core's documented DriftStatus semantics: "Computed-attribute
-# false positives surface in resource_drift but not in resource_changes" →
-# Detected=true, Actionable=false → informational notice, not blocking.
-# In --strict mode, actionable still reflects plan content only (Option 1
-# from #95); strict-mode alarm is conveyed via exit code, not this field.
+# Write drift report. Two top-level booleans:
+#   actionable     — at least one drifted resource has a non-no-op/read entry
+#                    in resource_changes[]. Reflects plan content only; matches
+#                    ui-core's documented DriftStatus semantics ("Computed-
+#                    attribute false positives surface in resource_drift but
+#                    not in resource_changes" → Detected=true, Actionable=false).
+#   apply_skipped  — true iff `actionable && !ignore_drift`. The apply
+#                    wrappers (apply-plan.sh, apply-with-outputs.sh) read
+#                    this and skip `terraform apply` when set. This moves
+#                    the apply gate out of the pod's exit code (issue #108)
+#                    while still letting reliable's force-apply round-trip
+#                    (UI → ignore_drift=true → Oracle → --ignore-drift)
+#                    flip it back to false on demand.
 mkdir -p "$OUTPUTS_DIR"
+
+if [[ "$ignore_drift" != "true" && "$actionable_drift_count" -gt 0 ]]; then
+  apply_skipped_json=true
+else
+  apply_skipped_json=false
+fi
+
 _drift_report="$(jq -n \
   --argjson drift "$drift" \
   --argjson count "$drift_count" \
   --argjson actionable "$actionable_drift_count" \
+  --argjson skipped "$apply_skipped_json" \
   --arg tmpl "${TEMPLATE_VERSION:-}" \
   --arg pres "${PRESETS_VERSION:-}" \
   '{
     drift_detected: true,
     drift_count: $count,
     actionable: ($actionable > 0),
+    apply_skipped: $skipped,
     template_version: (if $tmpl == "" then null else $tmpl end),
     presets_version: (if $pres == "" then null else $pres end),
     resources: $drift
@@ -208,13 +229,20 @@ else
 fi
 
 if [[ "$ignore_drift" == "true" ]]; then
-  echo "WARNING: Drift ignored (--ignore-drift flag set)."
+  echo "WARNING: Drift ignored (--ignore-drift flag set); force-applying despite drift (apply_skipped=false)."
   exit 0
 fi
 
-if [[ "$strict" != "true" && "$actionable_drift_count" -eq 0 ]]; then
+if [[ "$strict" == "true" ]]; then
+  # Standalone refresh-only alarm path (drift-refresh.sh). Any drift exits 2
+  # so the caller's workflow step fails visibly. Apply paths do not pass
+  # --strict, so this never fires for them.
+  exit 2
+fi
+
+if [[ "$actionable_drift_count" -gt 0 ]]; then
+  echo "INFO: actionable drift detected; apply_skipped=true. Apply wrappers will skip terraform apply. See reliable + UI for verdict."
+else
   echo "INFO: drift detected but no drifted resource is being applied; not blocking apply."
-  exit 0
 fi
-
-exit 2
+exit 0


### PR DESCRIPTION
## Summary

- `drift-check.sh` no longer exits 2 on actionable drift. The pod becomes a pure reporter — always exits 0 (except `--strict` for `drift-refresh.sh`'s standalone alarm path), writes `apply_skipped:true` into `drift.json` when actionable drift is detected without `--ignore-drift`.
- The apply gate moves into `apply-plan.sh` and `apply-with-outputs.sh`, which read `drift.json` after drift-check and skip `terraform apply` when `apply_skipped:true`.
- `--ignore-drift` is preserved — it's the only end-to-end force-apply signal reliable has today (UI → `/api/tf/start?ignore_drift=true` → Oracle workflow argv → drift-check). Removing it would break reliable's force-apply UX.

Closes #108.

## ⚠️ Do not merge yet — soak window

Issue #108 requires `reliable#1255` (consumes `pkg/drift.Classify`) to soak ≥ 2 weeks against real drift in dev/staging before this lands. `reliable#1255` merged 2026-05-02. **Earliest safe merge: ~2026-05-16.** If reliable's classifier misclassifies during that window and we've already shipped this, every drift-detected run silently no-ops the apply because no one is gating.

## Behavior matrix

| Scenario | drift-check exit | `apply_skipped` | terraform apply runs? |
|---|---|---|---|
| no drift | 0 | false | yes |
| drift, non-actionable (computed/no-op) | 0 | false | yes (preserves today) |
| drift, actionable, no `--ignore-drift` | 0 | **true** (NEW) | **no** (NEW) |
| drift, actionable, `--ignore-drift` | 0 | false | yes (force) |
| drift + `--strict` (refresh-only path) | 2 | true | n/a |

`apply_skipped = drift_detected && actionable && !ignore_drift` — deterministic from existing fields.

## How force-apply still works end-to-end

The chain that motivates keeping `--ignore-drift`:

1. UI → `reliable POST /api/tf/start?ignore_drift=true`
2. `reliable/internal/agentapi/tf_start.go:668-671` → `payload["ignoreDrift"]=true` to Oracle
3. `ui-core/jobs/workflows/workflows.go:366-378` → appends `--ignore-drift` to argv: `bash apply-plan.sh <stage> --plan-file <id> --check-drift --ignore-drift`
4. `apply-plan.sh` / `apply-with-outputs.sh` pass it through to `drift-check.sh`

Reliable does **not** signal the pod synchronously. It classifies for display (`drift_classification` on `/api/tf/status`); force-apply is a round trip — user clicks "force apply", reliable re-kicks the workflow with `ignore_drift=true`. So `--ignore-drift` is the sole, end-to-end force-apply signal.

## Test plan

- [x] `bash tests/test-drift-check.sh` — 126 pass, 0 fail. Tests 2, 8, 10, 12, 23–28, 30–32 inverted from "expect exit 2" to "expect exit 0 + apply_skipped:true". Tests 19–22 (`--strict` paths) unchanged at exit 2. New Test 39 locks down the full exit/apply_skipped matrix in one place.
- [x] `bash tests/test-apply-scripts.sh` — 63 pass, 0 fail. Tests 3 and 7 inverted: drift detected → exit 0 + `terraform apply` not called (wrapper honors `apply_skipped`). New Test 7b proves `--ignore-drift` force-apply path.
- [x] `bash -n` and `shellcheck -S warning` clean on all changed scripts.
- [x] `tests/test-plan-all.sh` shows 5 pre-existing failures unrelated to this PR (`plan-all.sh` exit-code drift from #67); confirmed identical results on `main`.
- [ ] Manual end-to-end against test Oracle once reliable#1255 has soaked: introduce known firestore-etag drift, confirm pod exits 0, drift.json shows `apply_skipped:false` (non-actionable per classifier) and apply runs.
- [ ] Manual force-apply: introduce real actionable drift, click "force apply" in UI, confirm `apply_skipped:false` and apply runs.

## Schema change

`drift.json` gains one additive top-level boolean:

```diff
 {
   "drift_detected": true,
   "drift_count": 1,
   "actionable": true,
+  "apply_skipped": true,
   "template_version": "...",
   "presets_version": "...",
   "resources": [...]
 }
```

`reliable`'s `pkg/drift.UnmarshalJSON` and `ui-core`'s pass-through both ignore unknown fields, so consumers see only an additive change.

## Out of scope (Phase 3 follow-ups)

- Drop `--ignore-drift` / `IGNORE_DRIFT` once reliable owns the gate uniformly.
- Drop `actionable` rollup if no consumers remain after reliable rolls out.
- An `--block-on-drift` opt-in for sensitive environments — obviated by this design (default IS skip-apply on actionable; `--ignore-drift` is the override).