### PR TITLE
fix(cloud-provision/gcp): add WIF pool + provider so Oracle EKS can impersonate insideout-mgmt

### DIFF
--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -284,12 +284,22 @@ _GCP_CREDENTIALS_FILE=""
 # and writes it to a temporary file with secure permissions.
 # Sets GOOGLE_APPLICATION_CREDENTIALS environment variable.
 # Returns: 0 on success, 1 on failure
+#
+# WIF short-circuit: when GOOGLE_OAUTH_ACCESS_TOKEN is already set in the
+# environment (Phase-2 ops where ui-core has minted an impersonated token via
+# Workload Identity Federation), there is nothing to do. The google provider
+# picks up the env var directly; no SA key file is needed.
 setupGCPCredentials() {
+  if [[ -n "${GOOGLE_OAUTH_ACCESS_TOKEN:-}" ]]; then
+    echo "GCP access token supplied via GOOGLE_OAUTH_ACCESS_TOKEN; skipping SA-key setup"
+    return 0
+  fi
+
   local creds_b64
   creds_b64=$(getTfVar "gcp_credentials_b64")
 
   if [[ -z "$creds_b64" || "$creds_b64" == "null" ]]; then
-    echo_error "ERROR: gcp_credentials_b64 not found in tfvars"
+    echo_error "ERROR: gcp_credentials_b64 not found in tfvars (and no GOOGLE_OAUTH_ACCESS_TOKEN set)"
     return 1
   fi
 

--- a/tf/cloud-provision/gcp-resources.tf.tmpl
+++ b/tf/cloud-provision/gcp-resources.tf.tmpl
@@ -51,6 +51,14 @@ locals {
   gcp_inspector_sa_id_out  = google_service_account.insideout_inspector.account_id
   gcp_management_sa_email  = google_service_account.insideout_management.email
   gcp_management_sa_id_out = google_service_account.insideout_management.account_id
+
+  # WIF (Workload Identity Federation) lets the InsideOut Oracle pod
+  # (running on EKS with IRSA) impersonate insideout-mgmt / insideout-inspector
+  # for steady-state operations, eliminating the dependency on a long-lived
+  # customer SA key after first apply. Only created when ui-core supplies the
+  # platform identity vars; existing customers without these vars set keep
+  # the legacy SA-key-only flow.
+  ui_platform_wif_enabled = var.platform_aws_account_id != "" && var.platform_eks_role_name != ""
 }
 
 # GCP soft-deletes service accounts with a 30-day retention window. If
@@ -154,6 +162,92 @@ resource "google_service_account_iam_member" "management_token_creator" {
 }
 
 # ============================================================================
+# Workload Identity Federation (Oracle EKS → impersonate insideout-mgmt)
+# ============================================================================
+# Replaces the customer SA key as the outer authenticated principal for
+# steady-state Phase-2 ops (re-deploys, drift checks, inspector token mints).
+# The customer SA key is still used on first apply to create the resources
+# below; afterwards the federated principal alone can impersonate
+# insideout-mgmt / insideout-inspector and the customer key is no longer
+# required.
+#
+# The pool/provider/bindings are gated by `ui_platform_wif_enabled` so existing
+# projects whose ui-core build does not yet supply the platform identity vars
+# continue to work unchanged.
+
+resource "google_iam_workload_identity_pool" "ui_platform" {
+  count = local.ui_platform_wif_enabled ? 1 : 0
+
+  project                   = var.gcp_project_id
+  workload_identity_pool_id = "ui-platform-${var.short_project_id}"
+  display_name              = "InsideOut UI Platform"
+  description               = "InsideOut Oracle (EKS) federated principal pool for impersonating insideout-mgmt / insideout-inspector"
+
+  # Pools soft-delete with a 30-day window; matches the rationale on the SAs
+  # above (issues #104, #106). Recreating a pool with the same ID inside the
+  # retention window is not handled by this template.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_iam_workload_identity_pool_provider" "ui_platform_aws" {
+  count = local.ui_platform_wif_enabled ? 1 : 0
+
+  project                            = var.gcp_project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.ui_platform[0].workload_identity_pool_id
+  workload_identity_pool_provider_id = "ui-platform-aws"
+  display_name                       = "InsideOut Oracle (EKS IRSA)"
+  description                        = "Trusts the InsideOut platform AWS account; principalSet attribute.aws_role gates to the Oracle pod's IRSA role"
+
+  aws {
+    account_id = var.platform_aws_account_id
+  }
+
+  attribute_mapping = {
+    "google.subject"        = "assertion.arn"
+    "attribute.aws_role"    = "assertion.arn.extract('assumed-role/{role}/')"
+    "attribute.aws_account" = "assertion.account"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_service_account_iam_member" "management_token_creator_wif" {
+  count = local.ui_platform_wif_enabled ? 1 : 0
+
+  service_account_id = google_service_account.insideout_management.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member = format(
+    "principalSet://iam.googleapis.com/%s/attribute.aws_role/%s",
+    google_iam_workload_identity_pool.ui_platform[0].name,
+    var.platform_eks_role_name,
+  )
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_service_account_iam_member" "inspector_token_creator_wif" {
+  count = local.ui_platform_wif_enabled ? 1 : 0
+
+  service_account_id = google_service_account.insideout_inspector.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member = format(
+    "principalSet://iam.googleapis.com/%s/attribute.aws_role/%s",
+    google_iam_workload_identity_pool.ui_platform[0].name,
+    var.platform_eks_role_name,
+  )
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# ============================================================================
 # GCP Outputs
 # ============================================================================
 
@@ -190,4 +284,23 @@ output "gcp_management_sa_email" {
 output "gcp_management_sa_id" {
   description = "ID of the GCP management service account"
   value       = local.gcp_management_sa_id_out
+}
+
+output "gcp_wif_provider_resource_name" {
+  description = "Full resource name of the AWS-type Workload Identity Provider (projects/<num>/locations/global/workloadIdentityPools/<pool>/providers/<provider>). Empty when WIF is not enabled. Consumed by ui-core to construct the externalaccount audience for STS."
+  value       = local.ui_platform_wif_enabled ? google_iam_workload_identity_pool_provider.ui_platform_aws[0].name : ""
+}
+
+output "gcp_wif_pool_resource_name" {
+  description = "Full resource name of the Workload Identity Pool. Empty when WIF is not enabled."
+  value       = local.ui_platform_wif_enabled ? google_iam_workload_identity_pool.ui_platform[0].name : ""
+}
+
+output "gcp_wif_principal_set" {
+  description = "principalSet:// URI of the federated principal that holds tokenCreator on insideout-mgmt and insideout-inspector. Empty when WIF is not enabled."
+  value = local.ui_platform_wif_enabled ? format(
+    "principalSet://iam.googleapis.com/%s/attribute.aws_role/%s",
+    google_iam_workload_identity_pool.ui_platform[0].name,
+    var.platform_eks_role_name,
+  ) : ""
 }

--- a/tf/cloud-provision/vars.tf
+++ b/tf/cloud-provision/vars.tf
@@ -128,3 +128,15 @@ variable "gcp_impersonate_service_account" {
   type        = string
   default     = ""
 }
+
+variable "platform_aws_account_id" {
+  description = "InsideOut platform AWS account ID. When set together with platform_eks_role_name, cloud-provision creates a per-project Workload Identity Pool + AWS provider so the Oracle pod's EKS IRSA role can impersonate insideout-mgmt / insideout-inspector without a long-lived customer SA key."
+  type        = string
+  default     = ""
+}
+
+variable "platform_eks_role_name" {
+  description = "IAM role name (no ARN, no path) of the Oracle pod's IRSA role. Federated principal is principalSet://...attribute.aws_role/<this>. Required together with platform_aws_account_id to enable WIF."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- Add per-project Workload Identity Pool + AWS-type provider in `tf/cloud-provision/gcp-resources.tf.tmpl`
- Bind `roles/iam.serviceAccountTokenCreator` on `insideout-mgmt` and `insideout-inspector` to the federated principal `principalSet://...attribute.aws_role/<platform_eks_role_name>`
- Output `gcp_wif_provider_resource_name`, `gcp_wif_pool_resource_name`, `gcp_wif_principal_set` so ui-core can pick them up from cloud-provision state
- `shell_utils.sh:setupGCPCredentials` short-circuits when `GOOGLE_OAUTH_ACCESS_TOKEN` is set so Phase-2 Argo jobs no longer need an SA-key file

## Why

All GCP deployments fail after **5 days** because Reliable's vault expires the customer's SA credential at that TTL, and today every Phase-2 GCP op (re-deploy, drift check, inspector token mint) uses that key as the outer authenticated principal that mints impersonation tokens for `insideout-mgmt`.

After this PR ships and a project re-runs cloud-provision, its `insideout-mgmt` and `insideout-inspector` SAs additionally trust the InsideOut Oracle pod's EKS IRSA role via WIF. ui-core's Phase-2 paths can then switch to using EKS IRSA → GCP STS → impersonate `insideout-mgmt` directly, with no customer key in the loop after first apply. That ui-core change is a separate PR and tracks `luthersystems/ui-core#153`.

## Backward compatibility

- `ui_platform_wif_enabled = var.platform_aws_account_id != "" && var.platform_eks_role_name != ""` — both vars default to `""`. Projects whose ui-core build does not yet pass the platform identity vars run the legacy SA-key-only flow with no resource diff.
- Existing `management_token_creator` / `inspector_token_creator` bindings (customer-SA-based) are unchanged — first apply still uses the customer key.
- New resources have `lifecycle.prevent_destroy = true` matching the existing SA policy (issues #104, #106) and because GCP soft-deletes pools for 30 days.

## Test plan

- [x] `terraform fmt -check` clean
- [x] `terraform validate` clean (GCP-only file selection)
- [x] `bash -n shell_utils.sh` clean
- [x] `shellcheck shell_utils.sh` clean
- [ ] On a sandbox GCP project: re-run cloud-provision with platform vars set; confirm pool + provider + bindings are created; confirm outputs surface non-empty values
- [ ] Without platform vars set: re-run cloud-provision; confirm zero diff (no new resources)
- [ ] After merging the ui-core counterpart: end-to-end Phase-2 op (drift check) succeeds without an archived SA key

## Related

- Upstream blocker: luthersystems/ui-core#153