### PR TITLE
fix(prepare): allow archive-supplied providers-*.tf through PRESERVE_PATTERNS

### DIFF
--- a/prepare-custom-stack.sh
+++ b/prepare-custom-stack.sh
@@ -44,6 +44,23 @@ CUSTOM_REF="${CUSTOM_REF:-main}"
 CUSTOM_AUTH="${CUSTOM_AUTH:-token}"
 
 # --- Preserve key files in TARGET_DIR ------------------------------------------------------------
+# These patterns identify wrapper-owned files that must survive when the
+# customer's archive (or upstream git repo) is rsynced into TARGET_DIR.
+#
+# IMPORTANT: entries WITHOUT a wildcard are matched as LITERAL filenames
+# (rsync's --exclude pattern semantics + shell glob over a single filename).
+# In particular, "providers.tf" matches only the wrapper's own stub providers.tf
+# — it does NOT match archive-supplied sibling files like "providers-imported.tf"
+# or "providers-aliases.tf". This is intentional: the wrapper stub uses
+# wrapper-only Terraform vars (var.cloud_provider, local.terraform_role_arn,
+# etc.) and must always win, but the archive is allowed to ship additional
+# root-level provider configuration in "providers-*.tf" files (e.g. an
+# `alias = "imported"` block for reverse-Terraform imports). Terraform merges
+# provider configs across all .tf files in a module, so the wrapper's
+# providers.tf and the archive's providers-*.tf coexist cleanly.
+#
+# DO NOT change "providers.tf" to "providers*.tf" — that would silently drop
+# archive-supplied providers-*.tf files. See tests for the lock-in.
 PRESERVE_PATTERNS=(
   "backend.tf"
   "providers.tf"

--- a/tests/test-prepare-custom-stack.sh
+++ b/tests/test-prepare-custom-stack.sh
@@ -84,6 +84,14 @@ mkdir -p "$ARCHIVE_DIR"
 echo "new-main" > "$ARCHIVE_DIR/main.tf"
 echo "new-variables" > "$ARCHIVE_DIR/variables.tf"
 echo "1.8.0" > "$ARCHIVE_DIR/.terraform-version"
+# Archive may legitimately ship providers-*.tf siblings (e.g. reverse-import alias).
+# These MUST slip through PRESERVE_PATTERNS even though the wrapper preserves the
+# literal "providers.tf". They coexist because Terraform merges provider configs
+# across .tf files in the same module.
+echo 'provider "aws" { alias = "imported" }' > "$ARCHIVE_DIR/providers-imported.tf"
+echo 'provider "aws" { alias = "secondary" }' > "$ARCHIVE_DIR/providers-aliases.tf"
+# Archive's own providers.tf must STILL be dropped (wrapper's stub wins).
+echo 'provider "aws" { region = "evil-archive-region" }' > "$ARCHIVE_DIR/providers.tf"
 
 ARCHIVE_TGZ="$WORKDIR/payload.tgz"
 tar -czf "$ARCHIVE_TGZ" -C "$ARCHIVE_DIR" .
@@ -163,6 +171,27 @@ else
   fail "variables.tf not copied from archive"
 fi
 
+# Archive-supplied providers-imported.tf and providers-aliases.tf must survive
+# the PRESERVE_PATTERNS filter (literal "providers.tf" must not match siblings).
+if [[ -f "$TARGET/providers-imported.tf" ]] && grep -q 'alias = "imported"' "$TARGET/providers-imported.tf"; then
+  pass "providers-imported.tf from archive survived PRESERVE_PATTERNS"
+else
+  fail "providers-imported.tf from archive was dropped (PRESERVE_PATTERNS too broad)"
+fi
+
+if [[ -f "$TARGET/providers-aliases.tf" ]] && grep -q 'alias = "secondary"' "$TARGET/providers-aliases.tf"; then
+  pass "providers-aliases.tf from archive survived PRESERVE_PATTERNS"
+else
+  fail "providers-aliases.tf from archive was dropped (PRESERVE_PATTERNS too broad)"
+fi
+
+# Archive's own providers.tf must NOT clobber the wrapper's stub (literal match).
+if [[ -f "$TARGET/providers.tf" ]] && [[ "$(cat "$TARGET/providers.tf")" == "existing-providers" ]]; then
+  pass "wrapper providers.tf still wins over archive's providers.tf (literal preserve)"
+else
+  fail "wrapper providers.tf was overwritten by archive's providers.tf (PRESERVE_PATTERNS broke)"
+fi
+
 # --- Repo-mode test ---
 echo ""
 echo "Setting up repo-mode test..."
@@ -174,6 +203,10 @@ mkdir -p "$REPO_SRC"
 echo "repo-main" > "$REPO_SRC/main.tf"
 echo "repo-vars" > "$REPO_SRC/variables.tf"
 echo "1.9.0" > "$REPO_SRC/.terraform-version"
+# Same coverage as the archive case: repo-supplied providers-*.tf siblings must
+# pass through, but a repo's own providers.tf must NOT clobber the wrapper stub.
+echo 'provider "aws" { alias = "imported" }' > "$REPO_SRC/providers-imported.tf"
+echo 'provider "aws" { region = "evil-repo-region" }' > "$REPO_SRC/providers.tf"
 (
   cd "$REPO_SRC"
   git init -q -b main
@@ -270,6 +303,19 @@ if [[ ! -f "$TARGET/stale-leftover.tf" ]]; then
   pass "repo mode: stale file removed by rsync --delete"
 else
   fail "repo mode: stale file NOT removed (rsync --delete may be broken)"
+fi
+
+if [[ -f "$TARGET/providers-imported.tf" ]] && grep -q 'alias = "imported"' "$TARGET/providers-imported.tf"; then
+  pass "repo mode: providers-imported.tf from repo survived PRESERVE_PATTERNS"
+else
+  fail "repo mode: providers-imported.tf from repo was dropped (PRESERVE_PATTERNS too broad)"
+fi
+
+# Repo's own providers.tf must NOT clobber the wrapper stub (literal preserve).
+if [[ -f "$TARGET/providers.tf" ]] && [[ "$(cat "$TARGET/providers.tf")" == "existing-providers" ]]; then
+  pass "repo mode: wrapper providers.tf still wins over repo's providers.tf"
+else
+  fail "repo mode: wrapper providers.tf was overwritten by repo's providers.tf"
 fi
 
 # --- Error-path test: missing both archive and repo URL ---


### PR DESCRIPTION
## Summary

Document and lock in the literal-match semantics of the `"providers.tf"` entry in `PRESERVE_PATTERNS` so archive-supplied sibling files like `providers-imported.tf` and `providers-aliases.tf` coexist with the wrapper's own `providers.tf` stub.

The wrapper's `providers.tf` uses wrapper-only Terraform vars (`var.cloud_provider`, `local.terraform_role_arn`, etc.) and must always win — but the archive is allowed to ship additional root-level provider configuration in `providers-*.tf` files (e.g. an `alias = "imported"` block for reverse-Terraform imports). Terraform merges provider configs across `.tf` files in the same module, so the two coexist cleanly.

## Why

The current `rsync --exclude "providers.tf"` pattern is **already a literal match** (not a glob), so `providers-*.tf` siblings already pass through. But the intent was undocumented, and a future maintainer could easily "fix" it to `providers*.tf` and silently drop the archive's files — breaking reverse-import deploys.

- Unblocks the upcoming `insideout-terraform-presets` PR that splits the composer's monolithic `/providers.tf` into `/providers.tf` + `/providers-aliases.tf` + `/providers-imported.tf`.
- Pairs with [luthersystems/reliable#1588](https://github.com/luthersystems/reliable/pull/1588) (the reverse-import workaround that wrote to a NEW filename specifically to sidestep `PRESERVE_PATTERNS`). With this PR landed, the workaround becomes the stable contract.

## Pattern change (before / after)

No semantic change in the rsync pattern itself — only documentation + tests. The literal entry stays exactly as it is:

```diff
 # --- Preserve key files in TARGET_DIR ---
+# IMPORTANT: entries WITHOUT a wildcard are matched as LITERAL filenames.
+# "providers.tf" matches only the wrapper's own stub — it does NOT match
+# archive-supplied "providers-imported.tf" / "providers-aliases.tf".
+# DO NOT change "providers.tf" to "providers*.tf" — that would silently drop
+# archive-supplied providers-*.tf files. See tests for the lock-in.
 PRESERVE_PATTERNS=(
   "backend.tf"
   "providers.tf"
   ...
 )
```

The teeth of the PR are the five new regression tests in `tests/test-prepare-custom-stack.sh` (archive mode + repo mode). They were verified to **fail** if `PRESERVE_PATTERNS` is broadened to `providers*.tf`, so they actively lock in the desired semantics.

## Test plan

- [x] `bash tests/test-prepare-custom-stack.sh` — all 42 tests pass (37 existing + 5 new).
- [x] Regression check: temporarily change `"providers.tf"` to `"providers*.tf"` in `PRESERVE_PATTERNS` → 3 new tests fail with `providers-imported.tf from archive was dropped (PRESERVE_PATTERNS too broad)`. Restoring the literal pattern → all pass again.
- [x] `bash -n prepare-custom-stack.sh tests/test-prepare-custom-stack.sh` clean.
- [x] `shellcheck -x -S warning` clean on both files.

New assertions cover:

- Archive's `providers-imported.tf` lands at `tf/custom-stack-provision/providers-imported.tf`.
- Archive's `providers-aliases.tf` lands at `tf/custom-stack-provision/providers-aliases.tf`.
- Archive's own `providers.tf` is **dropped** — wrapper's stub still wins (literal preserve).
- Same coverage in repo-mode (`git clone` path).