### PR TITLE
Support Mars Go entrypoint and reverse import wrapper

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -137,5 +137,6 @@ jobs:
           bash tests/test-prepare-custom-stack.sh
           bash tests/test-tf-destroy-init.sh
           bash tests/test-mars-entrypoint-compat.sh
+          bash tests/test-reverse-import-wrapper.sh
           bash tests/test-external-id.sh
           bash tests/test-state-backend-output-parity.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -136,5 +136,6 @@ jobs:
         run: |
           bash tests/test-prepare-custom-stack.sh
           bash tests/test-tf-destroy-init.sh
+          bash tests/test-mars-entrypoint-compat.sh
           bash tests/test-external-id.sh
           bash tests/test-state-backend-output-parity.sh

--- a/ansible/ansible.sh
+++ b/ansible/ansible.sh
@@ -3,7 +3,12 @@ set -euo pipefail
 
 ANSIBLE_PLAYBOOK_OPTS=${ANSIBLE_PLAYBOOK_OPTS:-""}
 
-MARS=/opt/mars/run.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MARS_PROJECT_ROOT:=$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+. "$MARS_PROJECT_ROOT/shell_utils.sh"
+
+MARS="$(resolveMarsBinary)"
 
 PLAYBOOK=$1
 

--- a/mars
+++ b/mars
@@ -4,11 +4,22 @@ set -eo pipefail
 
 DEV_MOUNTS=''
 if [[ "$MARS_DEV" == "true" ]]; then
-  DEFAULT_MARS_DEV_ROOT="$(dirname $(greadlink -f $(which mars)))"
-  MARS_DEV_ROOT=${MARS_DEV_ROOT:-DEFAULT_MARS_DEV_ROOT}
-  DEV_MOUNTS="-v ${MARS_DEV_ROOT}/scripts:/opt/mars:ro \
-                -v ${MARS_DEV_ROOT}/ansible-roles:/opt/ansible/roles:ro \
+  DEFAULT_MARS_DEV_ROOT="$(dirname "$(greadlink -f "$(which mars)")")"
+  MARS_DEV_ROOT=${MARS_DEV_ROOT:-$DEFAULT_MARS_DEV_ROOT}
+  DEV_MOUNTS="-v ${MARS_DEV_ROOT}/ansible-roles:/opt/ansible/roles:ro \
                 -v ${MARS_DEV_ROOT}/ansible-plugins:/opt/ansible/plugins:ro"
+  if [[ -n "${MARS_DEV_BINARY:-}" ]]; then
+    DEV_MOUNTS="-v ${MARS_DEV_BINARY}:/opt/mars/mars:ro ${DEV_MOUNTS}"
+  fi
+  if [[ -n "${MARS_DEV_ENTRYPOINT:-}" ]]; then
+    DEV_MOUNTS="-v ${MARS_DEV_ENTRYPOINT}:/opt/mars/mars-entrypoint:ro ${DEV_MOUNTS}"
+  fi
+  if [[ -n "${MARS_DEV_VAULT_AWS:-}" ]]; then
+    DEV_MOUNTS="-v ${MARS_DEV_VAULT_AWS}:/opt/mars/vault-aws-secretsmanager:ro ${DEV_MOUNTS}"
+  fi
+  if [[ -n "${MARS_DEV_VAULT_AZ:-}" ]]; then
+    DEV_MOUNTS="-v ${MARS_DEV_VAULT_AZ}:/opt/mars/vault-az-keyvault:ro ${DEV_MOUNTS}"
+  fi
 fi
 
 if [[ "$MARS_DEBUG" == "true" ]]; then
@@ -21,7 +32,7 @@ fullpath() {
 
 getroot() {
   GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-  if [ -z "$PROJECT_PATH"]; then
+  if [ -z "${PROJECT_PATH:-}" ]; then
     if [ -n "$GIT_ROOT" ]; then
       PROJECT_PATH="$GIT_ROOT"
     fi
@@ -29,16 +40,6 @@ getroot() {
 }
 
 CLONE_DIR=${CLONE_DIR:-$HOME}
-
-# NOTE:  ANSIBLE_INVENTORY_CACHE_MOUNT is a property of the ec2.py configuration
-# (in ec2.ini) which defaults to ~/.ansible (/opt/home/.ansible in the
-# container).  So it is possible for an inventory configuration to fail by
-# changing the property from its default value.
-# NOTE2:  Because Docker Desktop on macos is not able to mount unix sockets the
-# inventory cache directory is persisted through a docker-native volume,
-# ANSIBLE_INVENTORY_CACHE_VOL.
-ANSIBLE_INVENTORY_CACHE_VOL=mars_ansible_inventory_cache
-ANSIBLE_INVENTORY_CACHE_MOUNT="/opt/home/.ansible"
 
 TFENV_CACHE_PATH="$CLONE_DIR/.mars/tfenv/versions"
 
@@ -51,7 +52,7 @@ ANSIBLE_CHARTS_DIR="$CLONE_DIR/.mars/helmcharts"
 DOCKER_IMAGE=luthersystems/mars
 DOCKER_PROJECT_PATH=/marsproject
 getroot
-PROJECT_PATH=$(fullpath ${PROJECT_PATH:-$(pwd)})
+PROJECT_PATH=$(fullpath "${PROJECT_PATH:-$(pwd)}")
 WORK_REL_PATH="${PWD#$PROJECT_PATH}" # Includes leading dir separator
 DOCKER_WORK_DIR="$DOCKER_PROJECT_PATH$WORK_REL_PATH"
 
@@ -65,9 +66,9 @@ fi
 
 MARS_VERSION=latest
 if [ -f "$PROJECT_PATH/.mars-version" ]; then
-  MARS_VERSION=$(cat $PROJECT_PATH/.mars-version)
+  MARS_VERSION=$(cat "$PROJECT_PATH/.mars-version")
 elif [ -f "$GIT_ROOT/.mars-version" ]; then
-  MARS_VERSION=$(cat $GIT_ROOT/.mars-version)
+  MARS_VERSION=$(cat "$GIT_ROOT/.mars-version")
 fi
 
 ENV_VARS=
@@ -77,7 +78,7 @@ if [ -n "${TF_LOG+x}" ]; then
 fi
 
 DOCKER_TERM_VARS=-i
-if [ -t 1 -a ! -p /dev/stdin ]; then
+if [ -t 1 ] && [ ! -p /dev/stdin ]; then
   DOCKER_TERM_VARS=-it
 fi
 
@@ -86,10 +87,10 @@ if [[ "$MARS_SHELL" == "true" ]]; then
   SHELL_OPTS="--entrypoint /bin/bash"
 fi
 
-mkdir -p $TFENV_CACHE_PATH
-mkdir -p $TF_PLUGIN_CACHE_DIR
-mkdir -p $ANSIBLE_HYPERLEDGER_DIR
-mkdir -p $ANSIBLE_CHARTS_DIR
+mkdir -p "$TFENV_CACHE_PATH"
+mkdir -p "$TF_PLUGIN_CACHE_DIR"
+mkdir -p "$ANSIBLE_HYPERLEDGER_DIR"
+mkdir -p "$ANSIBLE_CHARTS_DIR"
 
 docker run --rm $DOCKER_TERM_VARS \
   --network host \

--- a/reverse-import.sh
+++ b/reverse-import.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MARS_PROJECT_ROOT:=$SCRIPT_DIR}"
+export MARS_PROJECT_ROOT
+
+. "$MARS_PROJECT_ROOT/shell_utils.sh"
+
+exportTemplateVersion
+exportPresetsVersion
+
+REVERSE_IMPORT_BIN="${REVERSE_IMPORT_BIN:-/usr/local/bin/insideout-reverse-import}"
+REVERSE_IMPORT_REQUEST="${REVERSE_IMPORT_REQUEST:-$MARS_PROJECT_ROOT/reverse-import/request.json}"
+REVERSE_IMPORT_OUT_DIR="${REVERSE_IMPORT_OUT_DIR:-$MARS_PROJECT_ROOT/outputs/reverse-import}"
+
+if [[ ! -f "$REVERSE_IMPORT_REQUEST" ]]; then
+  echo "ERROR: reverse-import request not found: $REVERSE_IMPORT_REQUEST" >&2
+  exit 1
+fi
+
+if [[ ! -x "$REVERSE_IMPORT_BIN" ]]; then
+  echo "ERROR: reverse-import binary is not executable: $REVERSE_IMPORT_BIN" >&2
+  exit 127
+fi
+
+mkdir -p "$REVERSE_IMPORT_OUT_DIR"
+
+if ! setupCloudEnv; then
+  echo "ERROR: failed to setup cloud environment" >&2
+  exit 1
+fi
+trap 'cleanupCloudEnv' EXIT
+
+echo "reverse_import_request=$REVERSE_IMPORT_REQUEST"
+echo "reverse_import_out_dir=$REVERSE_IMPORT_OUT_DIR"
+
+set +e
+"$REVERSE_IMPORT_BIN" \
+  --request "$REVERSE_IMPORT_REQUEST" \
+  --out-dir "$REVERSE_IMPORT_OUT_DIR"
+status=$?
+set -e
+
+if [[ "$status" -ne 0 ]]; then
+  echo "ERROR: reverse-import job failed with exit code $status; preserving artifacts in $REVERSE_IMPORT_OUT_DIR" >&2
+fi
+
+exit "$status"

--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -15,6 +15,15 @@ echo_error() {
   echo "$1" >&2
 }
 
+resolveMarsBinary() {
+  local mars_root="${MARS_CONTAINER_ROOT:-/opt/mars}"
+  if [[ -x "$mars_root/mars" ]]; then
+    echo "$mars_root/mars"
+    return 0
+  fi
+  echo "$mars_root/run.sh"
+}
+
 # getAnsibleField <key>
 getAnsibleField() {
   key="$1"

--- a/tests/test-mars-entrypoint-compat.sh
+++ b/tests/test-mars-entrypoint-compat.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=/dev/null
+. "$ROOT/shell_utils.sh"
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+old_root="$WORKDIR/old"
+new_root="$WORKDIR/new"
+mkdir -p "$old_root" "$new_root"
+
+touch "$old_root/run.sh"
+chmod +x "$old_root/run.sh"
+
+touch "$new_root/run.sh" "$new_root/mars"
+chmod +x "$new_root/run.sh" "$new_root/mars"
+
+export MARS_CONTAINER_ROOT="$old_root"
+old_bin="$(resolveMarsBinary)"
+if [[ "$old_bin" != "$old_root/run.sh" ]]; then
+  echo "expected old Mars resolver to use run.sh, got $old_bin" >&2
+  exit 1
+fi
+
+export MARS_CONTAINER_ROOT="$new_root"
+new_bin="$(resolveMarsBinary)"
+if [[ "$new_bin" != "$new_root/mars" ]]; then
+  echo "expected new Mars resolver to use mars binary, got $new_bin" >&2
+  exit 1
+fi
+
+mock_bin="$WORKDIR/bin"
+mock_mars_root="$WORKDIR/mars-dev"
+docker_log="$WORKDIR/docker.log"
+mkdir -p "$mock_bin" "$mock_mars_root"
+touch "$mock_mars_root/mars" "$mock_mars_root/mars-entrypoint"
+chmod +x "$mock_mars_root/mars" "$mock_mars_root/mars-entrypoint"
+
+cat > "$mock_bin/docker" <<OUTER
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$docker_log"
+OUTER
+chmod +x "$mock_bin/docker"
+
+cat > "$mock_bin/greadlink" <<'OUTER'
+#!/usr/bin/env bash
+if [[ "$1" == "-f" ]]; then
+  shift
+fi
+printf '%s\n' "$1"
+OUTER
+chmod +x "$mock_bin/greadlink"
+
+cat > "$mock_bin/mars" <<OUTER
+#!/usr/bin/env bash
+exec "$ROOT/mars" "\$@"
+OUTER
+chmod +x "$mock_bin/mars"
+
+(
+  export PATH="$mock_bin:$PATH"
+  export HOME="$WORKDIR/home"
+  export MARS_DEV=true
+  export MARS_DEV_BINARY="$mock_mars_root/mars"
+  export MARS_DEV_ENTRYPOINT="$mock_mars_root/mars-entrypoint"
+  export MARS_DEV_ROOT="$mock_mars_root"
+  export MARS_DEBUG=false
+  export MARS_SHELL=false
+  export MARS_AZ=false
+  bash "$ROOT/mars" version
+)
+
+if grep -q "$mock_mars_root/scripts:/opt/mars:ro" "$docker_log"; then
+  echo "expected MARS_DEV mode not to mount removed scripts directory" >&2
+  exit 1
+fi
+
+if ! grep -q "$mock_mars_root/mars:/opt/mars/mars:ro" "$docker_log"; then
+  echo "expected MARS_DEV_BINARY to mount the Go Mars binary" >&2
+  exit 1
+fi
+
+if ! grep -q "$mock_mars_root/mars-entrypoint:/opt/mars/mars-entrypoint:ro" "$docker_log"; then
+  echo "expected MARS_DEV_ENTRYPOINT to mount the Go Mars entrypoint helper" >&2
+  exit 1
+fi

--- a/tests/test-reverse-import-wrapper.sh
+++ b/tests/test-reverse-import-wrapper.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+PROJECT="$WORKDIR/project"
+BIN_LOG="$WORKDIR/bin.log"
+CLOUD_LOG="$WORKDIR/cloud.log"
+EVENT_LOG="$WORKDIR/events.log"
+mkdir -p "$PROJECT/reverse-import" "$PROJECT/outputs" "$WORKDIR/bin"
+
+cat > "$PROJECT/shell_utils.sh" <<OUTER
+#!/usr/bin/env bash
+set -euo pipefail
+
+exportTemplateVersion() {
+  echo "template_version=test-template"
+  export TEMPLATE_VERSION=test-template
+}
+
+exportPresetsVersion() {
+  echo "presets_version=test-presets"
+  export PRESETS_VERSION=test-presets
+}
+
+setupCloudEnv() {
+  echo "setupCloudEnv" >> "$CLOUD_LOG"
+  echo "setupCloudEnv" >> "$EVENT_LOG"
+}
+
+cleanupCloudEnv() {
+  echo "cleanupCloudEnv" >> "$CLOUD_LOG"
+  echo "cleanupCloudEnv" >> "$EVENT_LOG"
+}
+OUTER
+
+cat > "$PROJECT/reverse-import/request.json" <<'OUTER'
+{"version":1,"resources":[]}
+OUTER
+
+FAKE_BIN="$WORKDIR/bin/insideout-reverse-import"
+cat > "$FAKE_BIN" <<OUTER
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%q ' "\$@" >> "$BIN_LOG"
+printf '\n' >> "$BIN_LOG"
+echo "insideout-reverse-import" >> "$EVENT_LOG"
+
+out_dir=""
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    --out-dir)
+      out_dir="\$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+mkdir -p "\$out_dir"
+echo '{"status":"succeeded"}' > "\$out_dir/reverse-result.json"
+echo '{"import_count":0}' > "\$out_dir/plan-summary.json"
+
+if [[ "\${FAKE_REVERSE_IMPORT_FAIL:-false}" == "true" ]]; then
+  echo '{"status":"failed"}' > "\$out_dir/reverse-result.json"
+  exit 42
+fi
+OUTER
+chmod +x "$FAKE_BIN"
+
+run_wrapper() {
+  (
+    export MARS_PROJECT_ROOT="$PROJECT"
+    export REVERSE_IMPORT_BIN="$FAKE_BIN"
+    bash "$ROOT/reverse-import.sh"
+  )
+}
+
+output="$(run_wrapper 2>&1)"
+
+if ! grep -q "template_version=test-template" <<<"$output"; then
+  echo "expected template provenance log in output" >&2
+  exit 1
+fi
+
+if ! grep -q "presets_version=test-presets" <<<"$output"; then
+  echo "expected presets provenance log in output" >&2
+  exit 1
+fi
+
+if ! grep -qx "setupCloudEnv" "$CLOUD_LOG"; then
+  echo "expected setupCloudEnv to run once before the binary" >&2
+  exit 1
+fi
+
+if ! grep -q -- "--request $PROJECT/reverse-import/request.json --out-dir $PROJECT/outputs/reverse-import" "$BIN_LOG"; then
+  echo "expected request and stable output paths in binary args; got:" >&2
+  cat "$BIN_LOG" >&2
+  exit 1
+fi
+
+if [[ ! -f "$PROJECT/outputs/reverse-import/reverse-result.json" ]]; then
+  echo "expected reverse-result.json under outputs/reverse-import" >&2
+  exit 1
+fi
+
+if ! grep -qx "cleanupCloudEnv" "$CLOUD_LOG"; then
+  echo "expected cleanupCloudEnv to run after success" >&2
+  exit 1
+fi
+
+expected_events=$'setupCloudEnv\ninsideout-reverse-import\ncleanupCloudEnv'
+if [[ "$(cat "$EVENT_LOG")" != "$expected_events" ]]; then
+  echo "expected setup, binary, cleanup order; got:" >&2
+  cat "$EVENT_LOG" >&2
+  exit 1
+fi
+
+: > "$CLOUD_LOG"
+: > "$BIN_LOG"
+: > "$EVENT_LOG"
+rm -rf "$PROJECT/outputs/reverse-import"
+
+set +e
+failure_output="$(
+  export MARS_PROJECT_ROOT="$PROJECT"
+  export REVERSE_IMPORT_BIN="$FAKE_BIN"
+  export FAKE_REVERSE_IMPORT_FAIL=true
+  bash "$ROOT/reverse-import.sh" 2>&1
+)"
+exit_code=$?
+set -e
+
+if [[ "$exit_code" -ne 42 ]]; then
+  echo "expected failing binary exit code 42, got $exit_code. Output: $failure_output" >&2
+  exit 1
+fi
+
+if [[ ! -f "$PROJECT/outputs/reverse-import/reverse-result.json" ]]; then
+  echo "expected failure artifacts to be preserved" >&2
+  exit 1
+fi
+
+if ! grep -qx "cleanupCloudEnv" "$CLOUD_LOG"; then
+  echo "expected cleanupCloudEnv to run after failure" >&2
+  exit 1
+fi
+
+if [[ "$(cat "$EVENT_LOG")" != "$expected_events" ]]; then
+  echo "expected setup, binary, cleanup order after failure; got:" >&2
+  cat "$EVENT_LOG" >&2
+  exit 1
+fi

--- a/tf/run-with-creds.sh
+++ b/tf/run-with-creds.sh
@@ -16,4 +16,4 @@ trap 'cleanupCloudEnv' EXIT
 # Hand off to the real Mars runner.
 # exec replaces this process, so the trap won't fire — the Mars container
 # handles its own cleanup on exit (same as prior behavior).
-exec /opt/mars/run.sh "$@"
+exec "$(resolveMarsBinary)" "$@"


### PR DESCRIPTION
## Summary

- Supports Mars v0.100 by resolving `/opt/mars/mars` first and falling back to `/opt/mars/run.sh` for older images.
- Adds `reverse-import.sh` as thin adapter glue around the future Mars `insideout-reverse-import` binary.
- Keeps shell-to-Go migration out of this PR; filed follow-up #114 for phased migration.

Closes #112
Closes #113

## Go conversion assessment

| Decision | Reason |
|---|---|
| Do not convert #112/#113 wrappers to Go now | These are thin adapter/compatibility shims; conversion would add packaging scope without moving semantics. |
| Phase Go later | Best candidates are JSON/Terraform-heavy scripts like `tf/drift-check.sh` and `tf/plan-all.sh`. |
| Keep script entrypoints stable | UI Core launches template scripts and consumes `/marsproject/outputs` artifacts today. |

Follow-up: #114

## Test plan

- [x] `bash tests/test-prepare-custom-stack.sh`
- [x] `bash tests/test-tf-destroy-init.sh`
- [x] `bash tests/test-mars-entrypoint-compat.sh`
- [x] `bash tests/test-reverse-import-wrapper.sh`
- [x] `bash tests/test-external-id.sh`
- [x] `bash tests/test-state-backend-output-parity.sh`
- [x] `zsh -lc 'set -o pipefail; rg --files -0 -g "*.sh" | xargs -0 -n1 bash -n'`
- [x] `zsh -lc 'files=("${(@f)$(rg --files -g "*.sh")}") ; shellcheck -x -S warning "$files[@]"'`
- [x] `git diff --check HEAD~2..HEAD`

## Security review

- No new API endpoints or auth surfaces.
- Reverse-import wrapper uses argv execution and validates request/binary paths before running.
- Credentials stay in the job environment via `setupCloudEnv`; no credentials are written into request/result JSON by this wrapper.
- Failure path preserves artifacts under `/marsproject/outputs/reverse-import`.

## QA review

- Added tests cover new/old Mars binary resolution, MARS_DEV mount behavior, reverse-import request/out-dir arguments, cloud setup/cleanup order, and artifact preservation on failure.
