### PR TITLE
Forward reverse-import provenance flags

### DIFF
--- a/reverse-import.sh
+++ b/reverse-import.sh
@@ -35,10 +35,19 @@ trap 'cleanupCloudEnv' EXIT
 echo "reverse_import_request=$REVERSE_IMPORT_REQUEST"
 echo "reverse_import_out_dir=$REVERSE_IMPORT_OUT_DIR"
 
-set +e
-"$REVERSE_IMPORT_BIN" \
-  --request "$REVERSE_IMPORT_REQUEST" \
+reverse_import_args=(
+  --request "$REVERSE_IMPORT_REQUEST"
   --out-dir "$REVERSE_IMPORT_OUT_DIR"
+)
+if [[ -n "${REVERSE_IMPORT_PROJECT_ID:-}" ]]; then
+  reverse_import_args+=(--import-project-id "$REVERSE_IMPORT_PROJECT_ID")
+fi
+if [[ -n "${REVERSE_IMPORT_SESSION_ID:-}" ]]; then
+  reverse_import_args+=(--import-session-id "$REVERSE_IMPORT_SESSION_ID")
+fi
+
+set +e
+"$REVERSE_IMPORT_BIN" "${reverse_import_args[@]}"
 status=$?
 set -e
 

--- a/tests/test-reverse-import-wrapper.sh
+++ b/tests/test-reverse-import-wrapper.sh
@@ -80,6 +80,8 @@ run_wrapper() {
   (
     export MARS_PROJECT_ROOT="$PROJECT"
     export REVERSE_IMPORT_BIN="$FAKE_BIN"
+    export REVERSE_IMPORT_PROJECT_ID="project-123"
+    export REVERSE_IMPORT_SESSION_ID="sess_v2_abc123"
     bash "$ROOT/reverse-import.sh"
   )
 }
@@ -103,6 +105,12 @@ fi
 
 if ! grep -q -- "--request $PROJECT/reverse-import/request.json --out-dir $PROJECT/outputs/reverse-import" "$BIN_LOG"; then
   echo "expected request and stable output paths in binary args; got:" >&2
+  cat "$BIN_LOG" >&2
+  exit 1
+fi
+
+if ! grep -q -- "--import-project-id project-123 --import-session-id sess_v2_abc123" "$BIN_LOG"; then
+  echo "expected import provenance in binary args; got:" >&2
   cat "$BIN_LOG" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Forward optional reverse-import project/session provenance env vars to Mars.
- Keep existing wrapper behavior for callers that do not set provenance env vars.
- Cover the forwarded argv contract in the reverse-import wrapper test.

## Test plan
- [x] bash tests/test-reverse-import-wrapper.sh
- [x] shellcheck -x -S warning reverse-import.sh tests/test-reverse-import-wrapper.sh

Closes #117
Related: luthersystems/ui-core#349