### PR TITLE
fix(plan-summary): include imports count in aggregated plan-summary.json

### DIFF
--- a/tests/test-plan-all.sh
+++ b/tests/test-plan-all.sh
@@ -195,10 +195,16 @@ else
   fail "no changes: has_changes should be false"
 fi
 
-if jq -e '.total.add == 0 and .total.change == 0 and .total.destroy == 0' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
+if jq -e '.total.add == 0 and .total.change == 0 and .total.destroy == 0 and .total.import == 0' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
   pass "no changes: totals are all zero"
 else
   fail "no changes: totals should be zero"
+fi
+
+if jq -e '.stages["cloud-provision"] | has("import")' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
+  pass "no changes: per-stage import field present"
+else
+  fail "no changes: per-stage import field missing"
 fi
 
 # ============================================================
@@ -595,6 +601,97 @@ fi
 
 # Clean up
 rm -f "$STAGE_PLANS_DIR/cloud-provision.apply-fail"
+
+# ============================================================
+# Test 10: Import actions counted correctly
+# ============================================================
+echo ""
+echo "Test 10: Import actions..."
+
+echo '{"resource_changes": []}' > "$STAGE_PLANS_DIR/cloud-provision.json"
+# custom-stack-provision: 1 import-only, 1 import+update, 1 create
+cat > "$STAGE_PLANS_DIR/custom-stack-provision.json" <<'EOF'
+{
+  "resource_changes": [
+    {"address": "aws_s3_bucket.imported", "change": {"actions": ["import"]}},
+    {"address": "aws_iam_role.imported_and_updated", "change": {"actions": ["import", "update"]}},
+    {"address": "aws_instance.new", "change": {"actions": ["create"]}}
+  ]
+}
+EOF
+
+set +e
+output="$(run_plan_all 2>&1)"
+exit_code=$?
+set -e
+
+if jq -e '.has_changes == true' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
+  pass "import: has_changes is true"
+else
+  fail "import: has_changes should be true"
+fi
+
+if jq -e '.total.import == 2' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
+  pass "import: total import is 2"
+else
+  fail "import: total import should be 2, got $(jq '.total.import' "$PROJECT/outputs/plan-summary.json")"
+fi
+
+if jq -e '.total.add == 1' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
+  pass "import: total add is 1 (import-only not counted as add)"
+else
+  fail "import: total add should be 1, got $(jq '.total.add' "$PROJECT/outputs/plan-summary.json")"
+fi
+
+if jq -e '.total.change == 1' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
+  pass "import: total change is 1 (import+update counted as change)"
+else
+  fail "import: total change should be 1, got $(jq '.total.change' "$PROJECT/outputs/plan-summary.json")"
+fi
+
+if jq -e '.stages["custom-stack-provision"].import == 2' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
+  pass "import: per-stage import is 2"
+else
+  fail "import: per-stage import should be 2, got $(jq '.stages["custom-stack-provision"].import' "$PROJECT/outputs/plan-summary.json")"
+fi
+
+# ============================================================
+# Test 11: Import-only triggers has_changes (no add/change/destroy)
+# ============================================================
+echo ""
+echo "Test 11: Import-only stage marks has_changes=true..."
+
+echo '{"resource_changes": []}' > "$STAGE_PLANS_DIR/cloud-provision.json"
+cat > "$STAGE_PLANS_DIR/custom-stack-provision.json" <<'EOF'
+{
+  "resource_changes": [
+    {"address": "aws_s3_bucket.imported", "change": {"actions": ["import"]}}
+  ]
+}
+EOF
+
+set +e
+output="$(run_plan_all 2>&1)"
+exit_code=$?
+set -e
+
+if jq -e '.has_changes == true' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
+  pass "import-only: has_changes is true"
+else
+  fail "import-only: has_changes should be true"
+fi
+
+if jq -e '.stages["custom-stack-provision"].has_changes == true' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
+  pass "import-only: per-stage has_changes is true"
+else
+  fail "import-only: per-stage has_changes should be true"
+fi
+
+if jq -e '.total.add == 0 and .total.change == 0 and .total.destroy == 0 and .total.import == 1' "$PROJECT/outputs/plan-summary.json" >/dev/null 2>&1; then
+  pass "import-only: only import is non-zero"
+else
+  fail "import-only: totals incorrect. Got: $(jq -c '.total' "$PROJECT/outputs/plan-summary.json")"
+fi
 
 # --- Summary ---
 echo ""

--- a/tf/plan-all.sh
+++ b/tf/plan-all.sh
@@ -104,17 +104,21 @@ for stage in $STAGES; do
 
   if [[ ! -f "$plan_file" ]]; then
     echo "WARNING: no plan JSON produced for stage $stage"
-    echo '{"add": 0, "change": 0, "destroy": 0, "has_changes": false}' > "$results_dir/$stage.json"
+    echo '{"add": 0, "change": 0, "destroy": 0, "import": 0, "has_changes": false}' > "$results_dir/$stage.json"
     continue
   fi
 
   # Extract resource change counts from plan JSON.
   # Filter out no-op actions (where actions == ["no-op"] or actions == ["read"]).
+  # Imports are counted from `change.actions[]` entries containing "import"
+  # (terraform JSON plan format v1+). A stage with imports-only is still a
+  # real change, so `has_changes` includes the import count.
   counts="$(jq '{
     add: [.resource_changes // [] | .[] | select(.change.actions | . != ["no-op"] and . != ["read"]) | select(.change.actions | contains(["create"]))] | length,
     change: [.resource_changes // [] | .[] | select(.change.actions | . != ["no-op"] and . != ["read"]) | select(.change.actions | contains(["update"]))] | length,
-    destroy: [.resource_changes // [] | .[] | select(.change.actions | . != ["no-op"] and . != ["read"]) | select(.change.actions | contains(["delete"]))] | length
-  } | . + {has_changes: ((.add + .change + .destroy) > 0)}' "$plan_file")"
+    destroy: [.resource_changes // [] | .[] | select(.change.actions | . != ["no-op"] and . != ["read"]) | select(.change.actions | contains(["delete"]))] | length,
+    import: [.resource_changes // [] | .[] | select(.change.actions | contains(["import"]))] | length
+  } | . + {has_changes: ((.add + .change + .destroy + .import) > 0)}' "$plan_file")"
 
   echo "$counts" > "$results_dir/$stage.json"
 
@@ -136,6 +140,7 @@ summary="$(
   total_add=0
   total_change=0
   total_destroy=0
+  total_import=0
 
   for stage in $STAGES; do
     stage_file="$results_dir/$stage.json"
@@ -147,6 +152,7 @@ summary="$(
         total_add=$((total_add + $(echo "$stage_data" | jq '.add')))
         total_change=$((total_change + $(echo "$stage_data" | jq '.change')))
         total_destroy=$((total_destroy + $(echo "$stage_data" | jq '.destroy')))
+        total_import=$((total_import + $(echo "$stage_data" | jq '.import // 0')))
       fi
       stages_json="$(echo "$stages_json" | jq --arg s "$stage" --argjson d "$stage_data" '.[$s] = $d')"
     fi
@@ -157,10 +163,11 @@ summary="$(
     --argjson total_add "$total_add" \
     --argjson total_change "$total_change" \
     --argjson total_destroy "$total_destroy" \
+    --argjson total_import "$total_import" \
     --argjson has_changes "$( [[ "$had_changes" == "true" ]] && echo "true" || echo "false" )" \
     '{
       stages: $stages,
-      total: { add: $total_add, change: $total_change, destroy: $total_destroy },
+      total: { add: $total_add, change: $total_change, destroy: $total_destroy, import: $total_import },
       has_changes: $has_changes
     }'
 )"


### PR DESCRIPTION
## Summary

`tf/plan-all.sh` was dropping Terraform's `import` count when aggregating per-stage results into `outputs/plan-summary.json`. A real plan reporting `Plan: 1 to import, 0 to add, 1 to change, 0 to destroy` was surfaced downstream as just `{add:0, change:1, destroy:0}`, with no import signal at all.

- Add an `import` field to each per-stage block and to the `total` block, computed from `resource_changes[].change.actions[]` containing `"import"` (Terraform JSON plan format v1+).
- Include `import` in `has_changes`, so an imports-only stage is correctly flagged as a real change.
- Add new test cases (`Test 10`, `Test 11`) covering import-only, import+update, and the mixed case. Existing tests also assert the new field is present.

Unblocks downstream UI work in [luthersystems/reliable2](https://github.com/luthersystems/reliable2) that needs to render import counts in the plan diff UI.

## Before / after

Before:
```json
{
  "stages": {
    "custom-stack-provision": { "add": 0, "change": 1, "destroy": 0, "has_changes": true }
  },
  "total": { "add": 0, "change": 1, "destroy": 0 },
  "has_changes": true
}
```

After:
```json
{
  "stages": {
    "custom-stack-provision": { "add": 0, "change": 1, "destroy": 0, "import": 1, "has_changes": true }
  },
  "total": { "add": 0, "change": 1, "destroy": 0, "import": 1 },
  "has_changes": true
}
```

## Notes

- Field name `import` (singular) chosen to match the existing `add` / `change` / `destroy` naming style.
- `has_changes` semantics: a stage with imports-only previously evaluated to `has_changes=false`; now it correctly evaluates to `true`. Justification inline in the script comment.
- An import+update entry (`actions: ["import", "update"]`) is counted in both `import` and `change` — matches how Terraform itself reports it in the plan summary line.
- The 5 preexisting test failures in `tests/test-plan-all.sh` (mock expects exit code 2 when `has_changes=true`, script returns 0) are unrelated and untouched.

## Test plan

- [x] `bash -n tf/plan-all.sh` (syntax)
- [x] `bash tests/test-plan-all.sh` — 9 new assertions pass; 5 preexisting unrelated failures unchanged (42 passed, 5 failed; was 33 passed, 5 failed)
- [x] shellcheck — no new findings
- [ ] CI green