### PR TITLE
fix(plan): emit outputs/tfplan.json so Oracle/reliable can serve the full plan JSON

### DIFF
--- a/tf/drift-refresh.sh
+++ b/tf/drift-refresh.sh
@@ -44,6 +44,11 @@ terraform plan -refresh-only -out=refresh.tfplan -input=false
 mkdir -p "$MARS_PROJECT_ROOT/outputs"
 terraform show -json refresh.tfplan > "$MARS_PROJECT_ROOT/outputs/tfplan-${lifecycle}.json"
 echo "Plan JSON written to $MARS_PROJECT_ROOT/outputs/tfplan-${lifecycle}.json"
+# Also write the canonical outputs/tfplan.json alias for consumers that
+# key on the unsuffixed name (Argo artifact spec, Oracle GetJobPlan,
+# reliable's fetchOraclePlanJSON). See issue #127.
+cp "$MARS_PROJECT_ROOT/outputs/tfplan-${lifecycle}.json" "$MARS_PROJECT_ROOT/outputs/tfplan.json"
+echo "Canonical tfplan.json written to $MARS_PROJECT_ROOT/outputs/tfplan.json"
 
 # Standalone drift alarm: --strict bypasses the plan-actionability gate in
 # drift-check.sh, since -refresh-only plans by definition have no actionable

--- a/tf/plan-all.sh
+++ b/tf/plan-all.sh
@@ -37,6 +37,15 @@ STAGES="${PLAN_STAGES:-cloud-provision custom-stack-provision}"
 OUTPUTS_DIR="$MARS_PROJECT_ROOT/outputs"
 mkdir -p "$OUTPUTS_DIR"
 
+# Clear stale plan artifacts from any prior run. Argo gives each workflow an
+# ephemeral marsproject so this is a no-op there, but local-dev re-runs (and
+# any reaped/retried Argo path that reuses the dir) would otherwise let a
+# previous-run tfplan-<stage>.json or tfplan.json survive a failed stage and
+# get picked up as the canonical alias below — feeding stale data to
+# reliable's tag-only classifier. Per-stage plan.sh invocations write their
+# own per-stage file and aren't affected.
+rm -f "$OUTPUTS_DIR"/tfplan-*.json "$OUTPUTS_DIR/tfplan.json"
+
 had_error=false
 had_changes=false
 

--- a/tf/plan-all.sh
+++ b/tf/plan-all.sh
@@ -9,6 +9,14 @@
 #
 # Outputs:
 #   outputs/tfplan-<stage>.json  Per-stage plan JSON (produced by plan.sh)
+#   outputs/tfplan.json          Canonical "full plan" alias for Argo / Oracle /
+#                                reliable consumers that expect a single
+#                                tfplan.json artifact (see issue #127). Sourced
+#                                from the import-bearing stage when present
+#                                (custom-stack-provision) so the post-import
+#                                tag-only classifier in reliable has the
+#                                resource_changes array it needs; otherwise
+#                                the last successful stage wins.
 #   outputs/plan-summary.json    Aggregated change counts across all stages
 #
 # Exit codes:
@@ -175,6 +183,33 @@ summary="$(
 echo "$summary" > "$OUTPUTS_DIR/plan-summary.json"
 echo "Plan summary written to $OUTPUTS_DIR/plan-summary.json"
 echo "$summary" | jq '.'
+
+# Write canonical outputs/tfplan.json alias for consumers that expect a
+# single full-plan artifact (Argo `tf-plan-all` artifact spec, Oracle
+# GetJobPlan → reliable's fetchOraclePlanJSON / post-import tag-only
+# classifier). See issue #127.
+#
+# Preference order:
+#   1. custom-stack-provision  (the stage that carries imports, so its
+#      resource_changes array is what the tag-only classifier reads)
+#   2. last successful stage in $STAGES with a per-stage plan JSON on disk
+canonical_src=""
+if [[ -f "$OUTPUTS_DIR/tfplan-custom-stack-provision.json" ]]; then
+  canonical_src="$OUTPUTS_DIR/tfplan-custom-stack-provision.json"
+else
+  for stage in $STAGES; do
+    if [[ -f "$OUTPUTS_DIR/tfplan-${stage}.json" ]]; then
+      canonical_src="$OUTPUTS_DIR/tfplan-${stage}.json"
+    fi
+  done
+fi
+
+if [[ -n "$canonical_src" ]]; then
+  cp "$canonical_src" "$OUTPUTS_DIR/tfplan.json"
+  echo "Canonical tfplan.json written from $canonical_src"
+else
+  echo "WARNING: no per-stage tfplan-*.json produced; skipping outputs/tfplan.json"
+fi
 
 # Exit codes
 if [[ "$had_error" == "true" ]]; then

--- a/tf/plan.sh
+++ b/tf/plan.sh
@@ -20,4 +20,11 @@ if [[ -n "$planfile" ]]; then
   local_ws="${workspace}"
   terraform show -json "$planfile" > "$MARS_PROJECT_ROOT/outputs/tfplan-${local_ws}.json"
   echo "Plan JSON written to $MARS_PROJECT_ROOT/outputs/tfplan-${local_ws}.json"
+  # Also write the canonical outputs/tfplan.json alias so single-stage
+  # Argo runs / consumers that key on the unsuffixed name pick this up
+  # (Argo `tf-plan-all` artifact spec, Oracle GetJobPlan, reliable's
+  # fetchOraclePlanJSON). See issue #127. plan-all.sh overwrites this
+  # alias to point at the import-bearing stage in multi-stage runs.
+  cp "$MARS_PROJECT_ROOT/outputs/tfplan-${local_ws}.json" "$MARS_PROJECT_ROOT/outputs/tfplan.json"
+  echo "Canonical tfplan.json written to $MARS_PROJECT_ROOT/outputs/tfplan.json"
 fi


### PR DESCRIPTION
## Summary

The Argo `tf-plan-all` workflow's artifact uploader has been silently logging on every staging run:

```
time="...Z" level=warning msg="cannot save artifact /marsproject/outputs/tfplan.json: no such file or directory"
time="...Z" level=info    msg="/marsproject/outputs/plan-summary.json -> ...plan-summary.json.tgz"
```

`plan-summary.json` is produced and uploaded, but `tfplan.json` (the full `terraform show -json` output) isn't. Downstream, Oracle's `GET /v1/ui/jobs/{job_id}/plan` returns `Plan: null`, reliable's `fetchOraclePlanJSON` returns `ErrPlanNotAvailable`, the post-import tag-only classifier never runs, and legitimate tag-only imports stay gated as "Plan shows drift after import".

## Regression chain — what broke in #43's wiring

[#43](https://github.com/luthersystems/sandbox-infrastructure-template/pull/43) wired `terraform show -json "$PLAN" > "$OUTPUTS_DIR/tfplan.json"` into `plan.sh` and `drift-refresh.sh`. That made the artifact exist and the warning go away.

[#45](https://github.com/luthersystems/sandbox-infrastructure-template/pull/45) ("multi-stage plan workflow with per-stage output naming") then refactored the output name to `outputs/tfplan-${workspace}.json` so each stage's plan JSON could coexist on disk for the new `plan-all.sh` aggregator. That broke the Argo artifact contract — nothing has written the unsuffixed `outputs/tfplan.json` the workflow looks for since.

Reliable already shipped a defense-in-depth fallback in [luthersystems/reliable#1761](https://github.com/luthersystems/reliable/pull/1761) that recovers `resource_changes` from `plan-summary.json` when Oracle echoes them. This PR makes that fallback obsolete by restoring the real artifact.

## Fix

Keep the per-stage `outputs/tfplan-${stage}.json` files (downstream consumers depend on the per-stage naming from #45) and additionally write a canonical `outputs/tfplan.json` alias:

- **`plan-all.sh`** — after the per-stage loop, `cp` the most relevant per-stage plan into `outputs/tfplan.json`. Preference: `custom-stack-provision` (the stage that carries imports — its `resource_changes` array is what reliable's tag-only classifier reads), else the last successful stage with a per-stage file on disk.
- **`plan.sh`** and **`drift-refresh.sh`** — also `cp` the per-stage file into `outputs/tfplan.json` so single-stage runs and standalone drift-refresh invocations satisfy the same Argo artifact spec.

## Related

- Closes #127
- [luthersystems/reliable#1761](https://github.com/luthersystems/reliable/pull/1761) — reliable-side fallback band-aid; this PR makes it obsolete.
- [luthersystems/ui-core#365](https://github.com/luthersystems/ui-core/issues/365) — even with `tfplan.json` present, Oracle should serve from S3 after the Argo workflow is GC'd. This PR is a prerequisite.

## Test plan

- [x] `bash -n tf/plan-all.sh tf/plan.sh tf/drift-refresh.sh` — syntax valid
- [x] `shellcheck tf/plan-all.sh tf/plan.sh tf/drift-refresh.sh` — no new warnings (pre-existing SC1091 on sourced files, SC2329 on trap-invoked cleanup, SC2086 in unrelated `$tf_workspace` expansion)
- [ ] On the next staging deploy, confirm the `cannot save artifact /marsproject/outputs/tfplan.json` warning is gone from the `tf-plan-all` artifact-uploader logs
- [ ] Confirm `s3://<argo-artifact-bucket>/.../tfplan.json.tgz` is non-empty for that run
- [ ] Confirm reliable's `fetchOraclePlanJSON` returns a populated `Plan` (not `ErrPlanNotAvailable`) for an import-bearing session