### PR TITLE
perf(tf): default plan parallelism to 20

### DIFF
--- a/tests/test-tf-destroy-init.sh
+++ b/tests/test-tf-destroy-init.sh
@@ -122,10 +122,12 @@ else
     fail "tfPlan: expected 1 MARS call, got $call_count"
   fi
 
-  if [[ "$first_call" == "default plan" ]]; then
-    pass "tfPlan: call is 'default plan'"
+  # tfPlan defaults to -parallelism=20 (override via TF_PARALLELISM).
+  expected_plan="default plan -parallelism=${TF_PARALLELISM:-20}"
+  if [[ "$first_call" == "$expected_plan" ]]; then
+    pass "tfPlan: call is '$expected_plan'"
   else
-    fail "tfPlan: expected 'default plan', got: $first_call"
+    fail "tfPlan: expected '$expected_plan', got: $first_call"
   fi
 fi
 

--- a/tf/utils.sh
+++ b/tf/utils.sh
@@ -45,11 +45,22 @@ tfInit() {
 }
 
 tfPlan() {
-  $MARS ${tf_workspace} plan
+  # Bump parallelism above terraform's default of 10 to speed up state
+  # refresh on customer stacks with many resources. AWS Describe* APIs
+  # tolerate 20 concurrent requests comfortably; reads are not throttle-
+  # sensitive the way writes are. Override via TF_PARALLELISM if needed.
+  $MARS ${tf_workspace} plan -parallelism="${TF_PARALLELISM:-20}"
 }
 
 tfApply() {
-  $MARS ${tf_workspace} apply --approve
+  # Apply hits write APIs which are more rate-limit sensitive than the
+  # plan-time Describe* calls, so we keep apply at terraform's default
+  # parallelism unless explicitly overridden via TF_APPLY_PARALLELISM.
+  if [[ -n "${TF_APPLY_PARALLELISM:-}" ]]; then
+    $MARS ${tf_workspace} apply -parallelism="${TF_APPLY_PARALLELISM}" --approve
+  else
+    $MARS ${tf_workspace} apply --approve
+  fi
 }
 
 tfDestroy() {


### PR DESCRIPTION
## Summary

- Bumps terraform plan default parallelism from 10 to 20 in `tf/utils.sh`'s `tfPlan()`.
- Adds `TF_PARALLELISM` env override so reliable / ui-core can tune it per-job.
- Leaves `tfApply()` at terraform's default (writes are rate-limit sensitive); exposes `TF_APPLY_PARALLELISM` for explicit opt-in.

## Why

Post-import preview plans for customer stacks with 30-50 AWS resources spend ~4 minutes in `terraform plan`. Profile shows state refresh fanning out 50+ `Describe*` calls through a 10-wide funnel. Bumping to 20 cuts the parallelism bottleneck in half.

Read-side AWS APIs (`Describe*`, `List*`) tolerate 20 concurrent callers easily — the API quota docs assume far higher concurrency than a single TF plan produces.

Save: ~1-2 min on the 4-minute refresh. Stacks on top of [mars v0.104.0](https://github.com/luthersystems/mars/releases/tag/v0.104.0) which removed the ~2 min Argo tar overhead via `filesystem_mirror` symlinks.

## Scope

`tfApply` intentionally untouched. Apply hits write APIs which ARE rate-limit sensitive — a hidden bump there could surface as throttling under load. `TF_APPLY_PARALLELISM` is available for callers that want to opt in.

## Test plan

- [x] `bash tests/test-plan-all.sh` — 41 passed (6 pre-existing failures on `main`, unrelated — all `expected exit 2, got 0` from the detailed-exitcode mock; not introduced by this change)
- [x] `bash tests/test-apply-scripts.sh` — 63 passed
- [x] `bash tests/test-prepare-custom-stack.sh` — 42 passed
- [x] `bash tests/test-drift-check.sh` — 126 passed
- [x] `bash tests/test-provider-selection.sh` — 20 passed
- [x] `shellcheck tf/utils.sh` — clean (one pre-existing SC1091 info about `bootstrap.sh` unchanged)
- [ ] Live validation: fresh tf plan on staging against `sess_v2_CnqUJ6NRJnLC` once this lands; compare with prior 9 min run