### PR TITLE
fix(tf): route -parallelism through TF_CLI_ARGS_plan (not direct CLI arg)

### DIFF
--- a/tests/test-tf-destroy-init.sh
+++ b/tests/test-tf-destroy-init.sh
@@ -20,9 +20,14 @@ MOCK_MARS="$WORKDIR/mock-mars.sh"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Create a mock MARS that logs all invocations (log path baked in at creation)
+# Also log TF_CLI_ARGS_plan / TF_CLI_ARGS_apply env vars on a second line so
+# tests can assert that flags routed through env (instead of direct CLI args
+# that the real $MARS wrapper would reject as unknown) were actually set.
 cat > "$MOCK_MARS" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >> "$MOCK_LOG"
+echo "TF_CLI_ARGS_plan=\${TF_CLI_ARGS_plan:-}" >> "$MOCK_LOG.env"
+echo "TF_CLI_ARGS_apply=\${TF_CLI_ARGS_apply:-}" >> "$MOCK_LOG.env"
 EOF
 chmod +x "$MOCK_MARS"
 
@@ -38,6 +43,7 @@ run_tf_func() {
   local func="$1"
   local mock="${2:-$MOCK_MARS}"
   : > "$MOCK_LOG"
+  : > "$MOCK_LOG.env"
   (
     cd "$STAGE_DIR"
     # Source utils.sh with workspace arg (positional $1 = "default")
@@ -122,12 +128,25 @@ else
     fail "tfPlan: expected 1 MARS call, got $call_count"
   fi
 
-  # tfPlan defaults to -parallelism=20 (override via TF_PARALLELISM).
-  expected_plan="default plan -parallelism=${TF_PARALLELISM:-20}"
-  if [[ "$first_call" == "$expected_plan" ]]; then
-    pass "tfPlan: call is '$expected_plan'"
+  # tfPlan threads `-parallelism=…` through TF_CLI_ARGS_plan (NOT as a
+  # direct CLI arg) because the real $MARS wrapper would reject `-p…`
+  # as an unknown flag — the mock in this test logs args but doesn't
+  # parse, which masked the issue originally. So the MARS call should
+  # be the bare `default plan`.
+  if [[ "$first_call" == "default plan" ]]; then
+    pass "tfPlan: call is 'default plan' (parallelism routed via TF_CLI_ARGS_plan)"
   else
-    fail "tfPlan: expected '$expected_plan', got: $first_call"
+    fail "tfPlan: expected 'default plan', got: $first_call"
+  fi
+
+  # Assert TF_CLI_ARGS_plan was set on the env passed to the mock. Without
+  # this assertion the test would happily pass even if the env-routing
+  # regressed back to a no-op (or back to the direct CLI form).
+  expected_env="TF_CLI_ARGS_plan=-parallelism=${TF_PARALLELISM:-20}"
+  if grep -q "^${expected_env}$" "$MOCK_LOG.env"; then
+    pass "tfPlan: TF_CLI_ARGS_plan='${expected_env#*=}' propagated to MARS env"
+  else
+    fail "tfPlan: expected env '$expected_env', got:"$'\n'"$(cat "$MOCK_LOG.env")"
   fi
 fi
 

--- a/tf/utils.sh
+++ b/tf/utils.sh
@@ -45,19 +45,36 @@ tfInit() {
 }
 
 tfPlan() {
-  # Bump parallelism above terraform's default of 10 to speed up state
-  # refresh on customer stacks with many resources. AWS Describe* APIs
-  # tolerate 20 concurrent requests comfortably; reads are not throttle-
-  # sensitive the way writes are. Override via TF_PARALLELISM if needed.
-  $MARS ${tf_workspace} plan -parallelism="${TF_PARALLELISM:-20}"
+  # Bump terraform's default plan parallelism (10) → 20 to halve the AWS
+  # Describe* refresh funnel on customer stacks with 30-50 resources.
+  # Override via TF_PARALLELISM if needed.
+  #
+  # IMPORTANT: must thread the flag through TF_CLI_ARGS_plan rather than
+  # passing `-parallelism=…` directly to $MARS. The $MARS wrapper parses
+  # unrecognized flags itself and errors with "unknown flag -p" before
+  # the call ever reaches the terraform binary inside the container.
+  # TF_CLI_ARGS_plan is read directly by terraform and prepended to its
+  # actual command line, so the parallelism flag lands where it belongs.
+  local parallelism="${TF_PARALLELISM:-20}"
+  local args="-parallelism=${parallelism}"
+  if [[ -n "${TF_CLI_ARGS_plan:-}" ]]; then
+    args="${TF_CLI_ARGS_plan} ${args}"
+  fi
+  TF_CLI_ARGS_plan="${args}" $MARS ${tf_workspace} plan
 }
 
 tfApply() {
   # Apply hits write APIs which are more rate-limit sensitive than the
   # plan-time Describe* calls, so we keep apply at terraform's default
   # parallelism unless explicitly overridden via TF_APPLY_PARALLELISM.
+  # Same wrapper-flag-parsing gotcha as tfPlan: thread through
+  # TF_CLI_ARGS_apply rather than the direct CLI.
   if [[ -n "${TF_APPLY_PARALLELISM:-}" ]]; then
-    $MARS ${tf_workspace} apply -parallelism="${TF_APPLY_PARALLELISM}" --approve
+    local args="-parallelism=${TF_APPLY_PARALLELISM}"
+    if [[ -n "${TF_CLI_ARGS_apply:-}" ]]; then
+      args="${TF_CLI_ARGS_apply} ${args}"
+    fi
+    TF_CLI_ARGS_apply="${args}" $MARS ${tf_workspace} apply --approve
   else
     $MARS ${tf_workspace} apply --approve
   fi


### PR DESCRIPTION
## Summary

- [#130](https://github.com/luthersystems/sandbox-infrastructure-template/pull/130)'s `$MARS ... plan -parallelism=20` broke the post-import preview path — the `$MARS` wrapper parses unknown flags before delegating, so it errored with `"unknown flag -p, did you mean \"-h\"?"` and `plan.sh` exited 80.
- The Argo workflow looped against the failing stage for ~47 minutes before giving up on `pcs-647e1dd9-dd9c5` against `sess_v2_CnqUJ6NRJnLC` post-deploy.
- Fix: thread the flag through `TF_CLI_ARGS_plan` (which terraform reads directly and prepends to its actual CLI) instead of passing it to `$MARS` as a direct arg.

## Why the original test missed this

The mock `$MARS` in `tests/test-tf-destroy-init.sh` logged its argv but didn't actually parse flags — so `default plan -parallelism=20` happily passed in the test while real mars rejected it.

## Test hardening (regression guard)

The mock now also captures `TF_CLI_ARGS_plan` and `TF_CLI_ARGS_apply` env vars on a sidecar `.env` log. A new positive assertion pins the expected env propagation:

```
PASS: tfPlan: TF_CLI_ARGS_plan='-parallelism=20' propagated to MARS env
```

If a future regression went back to the direct-CLI form (or dropped the env routing entirely), this assertion would fail instead of being masked by the mock.

## Test plan

- [x] `bash tests/test-tf-destroy-init.sh` — 12/12 pass (was 11/11)
- [ ] CI on this PR
- [ ] After merge: bump `SandboxTemplateRef` in reliable
- [ ] Re-run `scripts/e2e-import-test.sh` against `sess_v2_CnqUJ6NRJnLC` — expect plan completes in ~1 min (vs 47-min broken loop pre-fix)

## Required follow-up

After merge: bump `SandboxTemplateRef` in [`reliable/internal/agentapi/tf_start.go`](https://github.com/luthersystems/reliable/blob/main/internal/agentapi/tf_start.go) to this commit's SHA.