### PR TITLE
perf(plan-all): strip .terraform/providers/ before pod exit

### DIFF
--- a/tf/plan-all.sh
+++ b/tf/plan-all.sh
@@ -220,6 +220,34 @@ else
   echo "WARNING: no per-stage tfplan-*.json produced; skipping outputs/tfplan.json"
 fi
 
+# Strip provider binaries before Argo tars /marsproject for its output
+# artifact. Each `terraform init --reconfigure` symlinks /opt/tf-plugin-cache
+# providers into the local .terraform/providers/ via mars's filesystem_mirror
+# (luthersystems/mars#168) — but when the baked provider version drifts ahead
+# of the mars cache, init falls back to direct registry download which COPIES
+# the binary into .terraform/providers/. Either way these are re-creatable
+# from the mars filesystem_mirror on the next pod's init, so they don't need
+# to round-trip through the workflow's S3 artifact (~750 MiB of provider
+# binary per stage per pod, observed at ~45s/upload on 2026-05-25 against
+# sess_v2_CnqUJ6NRJnLC).
+#
+# .terraform/modules/ is intentionally KEPT — those are git clones of
+# luthersystems/tf-modules that the next pod would otherwise re-clone (no
+# filesystem mirror equivalent for module sources).
+#
+# .terraform/{providers,plugins}-lock.json and the lockfile (.terraform.lock.hcl)
+# are also kept — they pin the resolved versions and are required for
+# `init --reconfigure` to find the right mirror entries.
+echo "=== Stripping .terraform/providers/ before exit (re-created from filesystem_mirror on next init) ==="
+for stage in $STAGES; do
+  providers_dir="$MARS_PROJECT_ROOT/tf/${stage}/.terraform/providers"
+  if [[ -d "$providers_dir" ]]; then
+    size_before=$(du -sh "$providers_dir" 2>/dev/null | awk '{print $1}')
+    rm -rf "$providers_dir"
+    echo "  stripped tf/${stage}/.terraform/providers/ (${size_before:-?} before)"
+  fi
+done
+
 # Exit codes
 if [[ "$had_error" == "true" ]]; then
   exit 1


### PR DESCRIPTION
## Summary

After `plan-all.sh`'s per-stage loop completes, recursively remove each stage's `.terraform/providers/` directory. The mars container's `filesystem_mirror` re-creates these symlinks on the next pod's `terraform init --reconfigure`, so the upload-then-recreate-on-download cycle is pure overhead.

## Why

Argo workflow `pcs-647e1dd9-ghqs8` (2026-05-25, sess_v2_CnqUJ6NRJnLC) showed the `state-dir` output artifact at **489 MiB / ~45s upload × 2 pods** — providers were inside the tar because terraform's resolved provider version drifted ahead of mars's baked version, forcing the `direct {}` registry download path that copies binaries into `.terraform/providers/` instead of the `filesystem_mirror` symlink path.

The companion version-pinning chain (luthersystems/mars#171 + luthersystems/insideout-terraform-presets#687) re-establishes symlink hits. This PR is defense-in-depth: any future version-drift won't silently re-inflate the tar.

## Intentionally kept in the tar

| Path | Reason |
|---|---|
| `.terraform/modules/` | Git clones of `luthersystems/tf-modules`, would otherwise re-clone per pod |
| `.terraform.lock.hcl` | Pins resolved versions; needed for `init --reconfigure` to find the right mirror entries |
| `.terraform/{providers,plugins}-lock.json` | Same |

## Test plan

- [x] `bash tests/test-plan-all.sh` — 41 pass / 6 pre-existing failures (unrelated, present on `main`)
- [ ] CI: full sandbox-infra test suite
- [ ] After landing + ref bump in reliable: rerun staging e2e against `sess_v2_CnqUJ6NRJnLC` and confirm `state-dir` artifact drops from 489 MiB to <50 MiB; per-pod upload drops from ~45s to a few seconds.