### PR TITLE
perf(plan-all): strip ALL .terraform/providers/ recursively (1.5 GiB / ~120s per kick)

### DIFF
--- a/tests/test-plan-all.sh
+++ b/tests/test-plan-all.sh
@@ -693,6 +693,104 @@ else
   fail "import-only: totals incorrect. Got: $(jq -c '.total' "$PROJECT/outputs/plan-summary.json")"
 fi
 
+# ============================================================
+# Test 12: Strip removes ALL .terraform/providers/ trees, not just per-stage.
+# Covers issue #134 — reverse-import leaves provider caches under
+# outputs/reverse-import/{,genconfig/}.terraform/providers/ that the
+# original per-stage strip missed.
+# ============================================================
+echo ""
+echo "Test 12: Recursive strip of .terraform/providers/..."
+
+echo '{"resource_changes": []}' > "$STAGE_PLANS_DIR/cloud-provision.json"
+echo '{"resource_changes": []}' > "$STAGE_PLANS_DIR/custom-stack-provision.json"
+
+# Seed provider caches at every depth the real archive can hit:
+#   - per-stage (already covered by #133)
+#   - outputs/reverse-import/.terraform/providers/
+#   - outputs/reverse-import/genconfig/.terraform/providers/
+provider_seed_paths=(
+  "tf/cloud-provision/.terraform/providers/registry.terraform.io/hashicorp/aws/6.46.0/linux_amd64"
+  "tf/custom-stack-provision/.terraform/providers/registry.terraform.io/hashicorp/aws/6.46.0/linux_amd64"
+  "outputs/reverse-import/.terraform/providers/registry.terraform.io/hashicorp/aws/6.46.0/linux_amd64"
+  "outputs/reverse-import/genconfig/.terraform/providers/registry.terraform.io/hashicorp/aws/6.46.0/linux_amd64"
+)
+for p in "${provider_seed_paths[@]}"; do
+  mkdir -p "$PROJECT/$p"
+  : > "$PROJECT/$p/terraform-provider-aws_v6.46.0_x5"
+done
+
+# Also seed sibling .terraform/{modules,plugins} content that must SURVIVE the
+# strip — the strip is intentionally narrow (providers only) so that modules
+# (git clones) and locks are preserved across pods.
+mkdir -p "$PROJECT/tf/cloud-provision/.terraform/modules"
+: > "$PROJECT/tf/cloud-provision/.terraform/modules/modules.json"
+: > "$PROJECT/tf/cloud-provision/.terraform.lock.hcl"
+
+set +e
+output="$(run_plan_all 2>&1)"
+exit_code=$?
+set -e
+
+# Per-stage provider dirs gone
+if [[ ! -d "$PROJECT/tf/cloud-provision/.terraform/providers" ]]; then
+  pass "strip-all: tf/cloud-provision/.terraform/providers removed"
+else
+  fail "strip-all: tf/cloud-provision/.terraform/providers should be removed"
+fi
+
+if [[ ! -d "$PROJECT/tf/custom-stack-provision/.terraform/providers" ]]; then
+  pass "strip-all: tf/custom-stack-provision/.terraform/providers removed"
+else
+  fail "strip-all: tf/custom-stack-provision/.terraform/providers should be removed"
+fi
+
+# Reverse-import provider dirs gone (the #134 fix)
+if [[ ! -d "$PROJECT/outputs/reverse-import/.terraform/providers" ]]; then
+  pass "strip-all: outputs/reverse-import/.terraform/providers removed (#134)"
+else
+  fail "strip-all: outputs/reverse-import/.terraform/providers should be removed (#134)"
+fi
+
+if [[ ! -d "$PROJECT/outputs/reverse-import/genconfig/.terraform/providers" ]]; then
+  pass "strip-all: outputs/reverse-import/genconfig/.terraform/providers removed (#134)"
+else
+  fail "strip-all: outputs/reverse-import/genconfig/.terraform/providers should be removed (#134)"
+fi
+
+# Siblings preserved
+if [[ -f "$PROJECT/tf/cloud-provision/.terraform/modules/modules.json" ]]; then
+  pass "strip-all: .terraform/modules/ preserved"
+else
+  fail "strip-all: .terraform/modules/ should be preserved"
+fi
+
+if [[ -f "$PROJECT/tf/cloud-provision/.terraform.lock.hcl" ]]; then
+  pass "strip-all: .terraform.lock.hcl preserved"
+else
+  fail "strip-all: .terraform.lock.hcl should be preserved"
+fi
+
+# Strip header is emitted (catches accidental removal of the block)
+if echo "$output" | grep -q "Stripping ALL .terraform/providers/"; then
+  pass "strip-all: header logged"
+else
+  fail "strip-all: header not logged. Output: $output"
+fi
+
+# Idempotent — a second invocation must not error even though the dirs
+# are already gone (mirrors a retried Argo step on the same marsproject).
+set +e
+output2="$(run_plan_all 2>&1)"
+exit_code2=$?
+set -e
+
+if [[ "$exit_code2" -eq 0 ]]; then
+  pass "strip-all: idempotent re-run exits 0"
+else
+  fail "strip-all: idempotent re-run expected exit 0, got $exit_code2. Output: $output2"
+fi
+
 # --- Summary ---
 echo ""
 echo "================================"

--- a/tf/plan-all.sh
+++ b/tf/plan-all.sh
@@ -231,6 +231,12 @@ fi
 # binary per stage per pod, observed at ~45s/upload on 2026-05-25 against
 # sess_v2_CnqUJ6NRJnLC).
 #
+# We strip RECURSIVELY across the whole project root rather than just per-stage
+# tf/<stage>/.terraform/providers — reverse-import also leaves provider caches
+# under outputs/reverse-import/.terraform/providers/ and
+# outputs/reverse-import/genconfig/.terraform/providers/ (issue #134, another
+# ~1.5 GiB on top of the per-stage cost).
+#
 # .terraform/modules/ is intentionally KEPT — those are git clones of
 # luthersystems/tf-modules that the next pod would otherwise re-clone (no
 # filesystem mirror equivalent for module sources).
@@ -238,15 +244,15 @@ fi
 # .terraform/{providers,plugins}-lock.json and the lockfile (.terraform.lock.hcl)
 # are also kept — they pin the resolved versions and are required for
 # `init --reconfigure` to find the right mirror entries.
-echo "=== Stripping .terraform/providers/ before exit (re-created from filesystem_mirror on next init) ==="
-for stage in $STAGES; do
-  providers_dir="$MARS_PROJECT_ROOT/tf/${stage}/.terraform/providers"
-  if [[ -d "$providers_dir" ]]; then
-    size_before=$(du -sh "$providers_dir" 2>/dev/null | awk '{print $1}')
-    rm -rf "$providers_dir"
-    echo "  stripped tf/${stage}/.terraform/providers/ (${size_before:-?} before)"
-  fi
-done
+echo "=== Stripping ALL .terraform/providers/ before exit (re-created from filesystem_mirror on next init) ==="
+while IFS= read -r providers_dir; do
+  [[ -z "$providers_dir" ]] && continue
+  rel="${providers_dir#"$MARS_PROJECT_ROOT"/}"
+  size_before=$(du -sh "$providers_dir" 2>/dev/null | awk '{print $1}')
+  find "$providers_dir" -mindepth 1 -delete 2>/dev/null || true
+  rmdir "$providers_dir" 2>/dev/null || true
+  echo "  stripped $rel (${size_before:-?} before)"
+done < <(find "$MARS_PROJECT_ROOT" -type d -name providers -path '*/.terraform/providers' 2>/dev/null)
 
 # Exit codes
 if [[ "$had_error" == "true" ]]; then


### PR DESCRIPTION
## Summary
- Replace the per-stage strip in `tf/plan-all.sh` (from #133) with a recursive `find` for every `.terraform/providers/` under `$MARS_PROJECT_ROOT`.
- Catches the two paths the original strip missed: `outputs/reverse-import/.terraform/providers/` and `outputs/reverse-import/genconfig/.terraform/providers/` — together ~1.5 GiB of duplicate AWS provider binary per kick (issue #134).
- Idempotent — providers are re-pulled from the mars filesystem_mirror on the next pod's `terraform init`.

## Test plan
- [x] New Test 12 in `tests/test-plan-all.sh` seeds provider caches at all four real-world paths (per-stage + reverse-import + reverse-import/genconfig) and asserts they are removed.
- [x] Same test asserts sibling `.terraform/modules/` and `.terraform.lock.hcl` survive (strip is intentionally narrow).
- [x] Idempotency: a second `plan-all.sh` invocation on the already-stripped tree still exits 0.
- [x] `bash -n` + `shellcheck -x -S warning` (CI level) clean.
- [ ] Confirm post-merge against a staging plan kick that Oracle `download_project` / `set_args` drop from ~17s / ~67s to single-digit seconds.

Closes #134