### PR TITLE
fix(gitignore): exclude .terraform/ from customer archive commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@ tf/auto-vars/skip_remote_state.auto.tfvars.json
 # Generated at deploy time by _selectCloudFiles() from .tf.tmpl templates
 tf/*/providers-*.tf
 tf/*/*-resources.tf
+
+# Terraform's tooling cache. Regenerable on next `terraform init` from
+# mars's filesystem_mirror. Without this rule the ~750 MiB AWS provider
+# binary that reverse-import populates under
+# outputs/reverse-import/{,genconfig/}.terraform/providers/ rides every
+# Oracle archive commit and accumulates ~168 MiB / commit in
+# .git/objects forever. See sandbox-infrastructure-template#136 (which
+# strips the worktree before targz) and ui-core#382 (the .git history
+# bloat follow-up).
+.terraform/


### PR DESCRIPTION
## Summary
- Adds `.terraform/` to the customer-archive `.gitignore`. Without it, Oracle's go-git workspace commits `.terraform/providers/` on every plan/apply kick, and ~750 MiB of AWS provider binary accumulates in `.git/objects` forever.
- Complements [#136](https://github.com/luthersystems/sandbox-infrastructure-template/pull/136) (worktree strip before tar) and ties to [ui-core#382](https://github.com/luthersystems/ui-core/issues/382) (one-time GC of the already-accumulated 168 MiB blob).

## Evidence

Staging customer archive on `umbrella-oracle` (2026-05-26):

```
182.8 MiB  marsproject/
167.7 MiB  marsproject/.git/objects   ← single 168 MiB loose blob = pre-#380 providers tarball
```

The blob is unreachable in the worktree (`#136` + `#380` strip it before tar.gz) but stays reachable in commit history because nothing GCs it. Every future kick that touches `.terraform/` would add another such blob until/unless this rule is in place.

For fresh customers this rule prevents the bloat from ever entering git history. Existing customers still need a one-time GC (tracked in ui-core#382) to drop the historical blob already there.

## Test plan
- [x] Sanity: confirm `.gitignore` syntax is right (added at end of file, no trailing whitespace issues).
- [ ] After this merges + a `SandboxTemplateRef` bump in reliable, run a fresh plan kick and confirm `marsproject/.git/objects` does not grow.

## Related
- [#136](https://github.com/luthersystems/sandbox-infrastructure-template/pull/136) — recursive provider-cache strip on plan-all.sh exit
- [ui-core#380](https://github.com/luthersystems/ui-core/pull/380) — strip on `uploadProject` (Oracle side)
- [ui-core#382](https://github.com/luthersystems/ui-core/issues/382) — one-time GC of existing history