### PR TITLE
fix: persist applied stack to <project>-infra repo on deploy (#143)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -141,3 +141,5 @@ jobs:
           bash tests/test-external-id.sh
           bash tests/test-state-backend-output-parity.sh
           bash tests/test-plan-all.sh
+          bash tests/test-apply-scripts.sh
+          bash tests/test-infra-push.sh

--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -113,6 +113,7 @@ configure_deploy_ssh() {
 
 ensure_infra_remote() {
   # repo_clone_ssh_url should be set via terraform auto-vars
+  # (written by tf/cloud-provision/repo.tf → tf/auto-vars/git_repo.auto.tfvars.json).
   url=$(getTfVar "repo_clone_ssh_url")
   if [ -n "$url" ]; then
     if git remote get-url infra >/dev/null 2>&1; then
@@ -121,12 +122,22 @@ ensure_infra_remote() {
       git remote add infra "$url"
     fi
     echo "🔧 infra remote configured → $url"
+  else
+    # Loud (not silent): a populated repo_clone_ssh_url is the contract that
+    # lets us push the applied stack back to <project>-infra. If it is missing
+    # the push will be skipped and the repo stays empty — make that visible so
+    # it cannot regress unnoticed (issue #143).
+    echo_error "WARNING: repo_clone_ssh_url is empty in $AUTO_VARS_DIR; infra remote NOT configured (gitPushInfra will skip)"
   fi
 }
 
 configure_git() {
   if ! has_git_repo; then
-    echo "⚠️  configure_git: no .git at $MARS_PROJECT_ROOT"
+    # Loud (not silent): without a .git the commit/push helpers below no-op and
+    # the infra repo stays empty. On a normal deploy prepare-custom-stack.sh's
+    # ensure_git_from_infra (or the cloned working tree) should have provided
+    # one — surface its absence rather than failing quietly (issue #143).
+    echo_error "WARNING: configure_git: no .git at $MARS_PROJECT_ROOT (git commit/push to infra will be skipped)"
     return 1
   fi
   pushd "$MARS_PROJECT_ROOT" >/dev/null
@@ -184,14 +195,59 @@ gitMergeOriginMain() {
 }
 
 gitPushInfra() {
+  # When INFRA_PUSH_REQUIRED=1 (set by the deploy persist path, persistInfra),
+  # a missing infra remote is treated as a hard failure instead of a silent
+  # no-op so an empty <project>-infra repo can never slip through a "successful"
+  # apply unnoticed (issue #143). Standalone callers (push.sh) keep the lenient
+  # default.
   pushd "$MARS_PROJECT_ROOT" >/dev/null
   if git remote get-url infra >/dev/null 2>&1; then
     echo "🚀 Pushing to infra…"
     git push infra HEAD
+  elif [ "${INFRA_PUSH_REQUIRED:-0}" = "1" ]; then
+    echo_error "ERROR: gitPushInfra: no infra remote configured but INFRA_PUSH_REQUIRED=1 — refusing to leave infra repo empty (issue #143)"
+    popd >/dev/null
+    return 1
   else
     echo "Skipping gitPushInfra: no infra remote configured"
   fi
   popd >/dev/null
+}
+
+# persistInfra commits the applied stack and pushes it to the <project>-infra
+# repo. This is the production deploy hook: Oracle/ui-core runs each stage via
+# apply-with-outputs.sh (not tf/apply.sh), so without an explicit call here the
+# commit/push that tf/apply.sh wires would never run and the infra repo would
+# stay empty even on a SUCCESSFUL apply (issue #143).
+#
+# Stages differ in whether they own a working-tree clone of the infra repo:
+#   - custom-stack-provision: prepare-custom-stack.sh's ensure_git_from_infra
+#     establishes .git (clones <project>-infra). This is where the customer's
+#     real Terraform lands and where the push must happen.
+#   - cloud-provision / bootstrap stages: no .git in the working tree — they
+#     provision the repo but have nothing of their own to push. Skipping is
+#     expected, not an error.
+#
+# So persistInfra keys off .git presence:
+#   - No .git  → warn and return 0 (nothing to persist from this stage).
+#   - Has .git → merge infra/main (no-op on a brand-new repo), commit, then push
+#     with INFRA_PUSH_REQUIRED=1 so a remote that can't be configured is a LOUD,
+#     non-zero failure instead of a silent no-op (the issue #143 failure mode).
+#
+# Args: $1 (optional) commit message.
+persistInfra() {
+  if ! has_git_repo; then
+    echo_error "WARNING: persistInfra: no .git at $MARS_PROJECT_ROOT; nothing to persist to infra repo from this stage"
+    return 0
+  fi
+
+  # Pull in any infra/main changes (no-op on a brand-new repo). Non-fatal: a
+  # merge conflict here should not block surfacing the apply, but is loud.
+  gitMergeInfraMain || echo_error "WARNING: persistInfra: gitMergeInfraMain reported a problem; continuing to commit/push"
+
+  gitCommit "${1:-auto-commit: infrastructure changes [ci skip]}"
+
+  INFRA_PUSH_REQUIRED=1 gitPushInfra
 }
 
 gitMergeInfraMain() {

--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -203,7 +203,15 @@ gitPushInfra() {
   pushd "$MARS_PROJECT_ROOT" >/dev/null
   if git remote get-url infra >/dev/null 2>&1; then
     echo "🚀 Pushing to infra…"
-    git push infra HEAD
+    # Check the push result explicitly rather than relying on the caller's
+    # set -e: a failed push must surface as a non-zero return (and a loud
+    # error) from this helper itself, so it can't silently no-op even when
+    # invoked from a `||`/conditional context (issue #143 hardening).
+    if ! git push infra HEAD; then
+      echo_error "ERROR: gitPushInfra: git push to infra failed"
+      popd >/dev/null
+      return 1
+    fi
   elif [ "${INFRA_PUSH_REQUIRED:-0}" = "1" ]; then
     echo_error "ERROR: gitPushInfra: no infra remote configured but INFRA_PUSH_REQUIRED=1 — refusing to leave infra repo empty (issue #143)"
     popd >/dev/null
@@ -214,6 +222,10 @@ gitPushInfra() {
   popd >/dev/null
 }
 
+# Lifecycle/stage that owns the customer Terraform and MUST land in the infra
+# repo. persistInfra fails hard if this stage can't persist (issue #143).
+INFRA_PERSIST_REQUIRED_STAGE="custom-stack-provision"
+
 # persistInfra commits the applied stack and pushes it to the <project>-infra
 # repo. This is the production deploy hook: Oracle/ui-core runs each stage via
 # apply-with-outputs.sh (not tf/apply.sh), so without an explicit call here the
@@ -222,22 +234,33 @@ gitPushInfra() {
 #
 # Stages differ in whether they own a working-tree clone of the infra repo:
 #   - custom-stack-provision: prepare-custom-stack.sh's ensure_git_from_infra
-#     establishes .git (clones <project>-infra). This is where the customer's
-#     real Terraform lands and where the push must happen.
-#   - cloud-provision / bootstrap stages: no .git in the working tree — they
-#     provision the repo but have nothing of their own to push. Skipping is
+#     (or the mars project checkout) provides .git. This is where the customer's
+#     real Terraform lands and where the push MUST happen — a missing .git here
+#     means the infra repo would stay empty, the exact issue #143 failure, so it
+#     is a hard error.
+#   - cloud-provision / bootstrap stages: may have no .git in the working tree —
+#     they provision the repo but have nothing of their own to push. Skipping is
 #     expected, not an error.
 #
-# So persistInfra keys off .git presence:
-#   - No .git  → warn and return 0 (nothing to persist from this stage).
+# So persistInfra keys off .git presence AND the stage:
+#   - No .git on the required stage ($INFRA_PERSIST_REQUIRED_STAGE) → ERROR,
+#     return non-zero (fail the deploy rather than silently leaving it empty).
+#   - No .git on any other stage → warn and return 0 (nothing to persist).
 #   - Has .git → merge infra/main (no-op on a brand-new repo), commit, then push
 #     with INFRA_PUSH_REQUIRED=1 so a remote that can't be configured is a LOUD,
 #     non-zero failure instead of a silent no-op (the issue #143 failure mode).
 #
-# Args: $1 (optional) commit message.
+# Args: $1 (optional) lifecycle/stage; $2 (optional) commit message.
 persistInfra() {
+  local stage="${1:-}"
+  local msg="${2:-auto-commit: infrastructure changes [ci skip]}"
+
   if ! has_git_repo; then
-    echo_error "WARNING: persistInfra: no .git at $MARS_PROJECT_ROOT; nothing to persist to infra repo from this stage"
+    if [ "$stage" = "$INFRA_PERSIST_REQUIRED_STAGE" ]; then
+      echo_error "ERROR: persistInfra: no .git at $MARS_PROJECT_ROOT for stage '$stage' — cannot push the applied customer stack; infra repo would stay empty (issue #143). prepare-custom-stack.sh's infra clone likely failed or repo_clone_ssh_url was empty."
+      return 1
+    fi
+    echo_error "WARNING: persistInfra: no .git at $MARS_PROJECT_ROOT; nothing to persist to infra repo from stage '${stage:-unknown}'"
     return 0
   fi
 
@@ -245,7 +268,7 @@ persistInfra() {
   # merge conflict here should not block surfacing the apply, but is loud.
   gitMergeInfraMain || echo_error "WARNING: persistInfra: gitMergeInfraMain reported a problem; continuing to commit/push"
 
-  gitCommit "${1:-auto-commit: infrastructure changes [ci skip]}"
+  gitCommit "$msg"
 
   INFRA_PUSH_REQUIRED=1 gitPushInfra
 }

--- a/tests/test-infra-push.sh
+++ b/tests/test-infra-push.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression tests for issue #143: the applied customer stack was never pushed
+# to the <project>-infra GitHub repo, so every infra repo stayed empty even on
+# a SUCCESSFUL apply.
+#
+# Root cause: the commit/push was wired only in tf/apply.sh, but Oracle/ui-core
+# drives deploys through tf/apply-with-outputs.sh --check-drift, whose
+# drift-check branch ran terraform directly with NO git operations. The push
+# helper (gitPushInfra) also silently returned 0 when no infra remote was
+# configured, so the gap was invisible.
+#
+# These tests use a REAL local bare repo as the `infra` remote (file://) so we
+# can assert the end-state the bug got wrong: the infra repo goes from empty to
+# populated. terraform/mars are mocked so no cloud access is needed.
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+WORKDIR="$(mktemp -d)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v jq &>/dev/null; then
+  echo "SKIP: jq is required for these tests" >&2
+  exit 0
+fi
+
+# Deterministic committer identity for the helpers' commits.
+export GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="test@luthersystems.com"
+export GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="test@luthersystems.com"
+
+# --- A real bare repo that plays the role of <project>-infra ---------------
+INFRA_BARE="$WORKDIR/infra.git"
+git init -q --bare -b main "$INFRA_BARE"
+
+bare_object_count() {
+  # 0 => empty repo (the issue #143 failure mode), >0 => populated.
+  git -C "$INFRA_BARE" rev-list --all --count 2>/dev/null || echo 0
+}
+
+# --- Build a fake project tree whose working dir IS a clone of the infra repo
+# (mirrors prepare-custom-stack.sh's ensure_git_from_infra state) -----------
+make_project() {
+  local proj="$1"
+  mkdir -p "$proj/tf/auto-vars" "$proj/tf/custom-stack-provision" \
+    "$proj/ansible/inventories/default/group_vars/all" "$proj/outputs"
+  echo "environment: test" \
+    > "$proj/ansible/inventories/default/group_vars/all/env.yaml"
+
+  # auto-vars: the contract that wires the push (written by cloud-provision's
+  # repo.tf in production).
+  jq -n --arg url "$INFRA_BARE" \
+    '{cloud_provider:"aws", repo_clone_ssh_url:$url}' \
+    > "$proj/tf/auto-vars/git_repo.auto.tfvars.json"
+
+  cp "$REPO_ROOT/shell_utils.sh" "$proj/shell_utils.sh"
+  cp "$REPO_ROOT/tf/utils.sh" "$proj/tf/utils.sh"
+  cp "$REPO_ROOT/tf/drift-check.sh" "$proj/tf/drift-check.sh"
+  cp "$REPO_ROOT/tf/apply-with-outputs.sh" "$proj/tf/apply-with-outputs.sh"
+  cp "$REPO_ROOT/tf/apply.sh" "$proj/tf/apply.sh"
+
+  # Establish .git as a clone of the (empty) infra repo, then add the applied
+  # stack content (what terraform would have produced).
+  (
+    cd "$proj"
+    git init -q -b main
+    git remote add infra "$INFRA_BARE"
+    echo "applied stack" > tf/custom-stack-provision/main.tf
+  )
+}
+
+# --- Mock binaries (terraform + mars) so apply-with-outputs can run ---------
+MOCK_BIN="$WORKDIR/bin"
+mkdir -p "$MOCK_BIN"
+TF_OUTPUT_JSON="$WORKDIR/output-json.json"
+echo '{"vpc_id": {"value": "vpc-123"}}' > "$TF_OUTPUT_JSON"
+
+cat > "$MOCK_BIN/terraform" <<OUTER
+#!/usr/bin/env bash
+if [[ "\$1" == "output" && "\$2" == "-json" ]]; then
+  cat "$TF_OUTPUT_JSON"
+elif [[ "\$1" == "show" && "\$2" == "-json" ]]; then
+  echo '{"resource_drift": []}'
+elif [[ "\$1" == "plan" ]]; then
+  for arg in "\$@"; do
+    if [[ "\$arg" == -out=* ]]; then touch "\${arg#-out=}"; fi
+  done
+fi
+# init/apply and all branches: succeed
+exit 0
+OUTER
+chmod +x "$MOCK_BIN/terraform"
+
+cat > "$MOCK_BIN/mars" <<'OUTER'
+#!/usr/bin/env bash
+exit 0
+OUTER
+chmod +x "$MOCK_BIN/mars"
+export PATH="$MOCK_BIN:$PATH"
+
+# ===========================================================================
+echo "=== persistInfra: applied stack is pushed (issue #143) ==="
+echo ""
+echo "Test 1: persistInfra populates the empty infra repo..."
+
+P1="$WORKDIR/p1"
+make_project "$P1"
+
+before="$(bare_object_count)"
+if [[ "$before" -eq 0 ]]; then
+  pass "precondition: infra repo starts empty (reproduces the bug's start state)"
+else
+  fail "precondition: infra repo not empty before push (count=$before)"
+fi
+
+set +e
+out1="$(
+  cd "$P1"
+  export MARS_PROJECT_ROOT="$P1"
+  . "$P1/shell_utils.sh"
+  persistInfra "test: apply" 2>&1
+)"
+rc1=$?
+set -e
+
+if [[ $rc1 -eq 0 ]]; then
+  pass "persistInfra: exit 0 on happy path"
+else
+  fail "persistInfra: expected exit 0, got $rc1. Output: $out1"
+fi
+
+after="$(bare_object_count)"
+if [[ "$after" -gt 0 ]]; then
+  pass "persistInfra: infra repo is NOW populated (was the issue #143 failure)"
+else
+  fail "persistInfra: infra repo STILL empty after push (issue #143 not fixed)"
+fi
+
+# The pushed commit must carry the applied stack content.
+if git -C "$INFRA_BARE" show main:tf/custom-stack-provision/main.tf 2>/dev/null \
+   | grep -q "applied stack"; then
+  pass "persistInfra: pushed main contains applied stack content"
+else
+  fail "persistInfra: pushed main does not contain applied stack content"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== apply-with-outputs.sh --check-drift pushes (production path) ==="
+echo ""
+echo "Test 2: drift-check deploy path populates the infra repo..."
+
+# Fresh bare + project so the count is unambiguous.
+rm -rf "$INFRA_BARE"
+git init -q --bare -b main "$INFRA_BARE"
+
+P2="$WORKDIR/p2"
+make_project "$P2"
+
+set +e
+out2="$(
+  cd "$P2/tf"
+  export MARS_PROJECT_ROOT="$P2"
+  export MARS="$MOCK_BIN/mars"
+  export HOME="$WORKDIR"
+  bash "$P2/tf/apply-with-outputs.sh" custom-stack-provision --check-drift 2>&1
+)"
+rc2=$?
+set -e
+
+if [[ $rc2 -eq 0 ]]; then
+  pass "drift-check path: exit 0"
+else
+  fail "drift-check path: expected exit 0, got $rc2. Output: $out2"
+fi
+
+# THE core regression assertion: pre-fix the drift-check branch did zero git
+# ops, so this stayed 0 and the test fails. Post-fix persistInfra runs.
+if [[ "$(bare_object_count)" -gt 0 ]]; then
+  pass "drift-check path: infra repo populated via apply-with-outputs.sh (issue #143)"
+else
+  fail "drift-check path: infra repo STILL empty after deploy (issue #143 regression)"
+fi
+
+if echo "$out2" | grep -q "Pushing to infra"; then
+  pass "drift-check path: push path was reached (logged 'Pushing to infra')"
+else
+  fail "drift-check path: push path NOT reached. Output: $out2"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== Loud-on-failure: no silent skip when remote is unconfigured ==="
+echo ""
+echo "Test 3: gitPushInfra with INFRA_PUSH_REQUIRED=1 and no remote fails loudly..."
+
+P3="$WORKDIR/p3"
+mkdir -p "$P3/tf/auto-vars" "$P3/ansible/inventories/default/group_vars/all"
+echo "environment: test" > "$P3/ansible/inventories/default/group_vars/all/env.yaml"
+echo '{}' > "$P3/tf/auto-vars/common.auto.tfvars.json"
+cp "$REPO_ROOT/shell_utils.sh" "$P3/shell_utils.sh"
+( cd "$P3" && git init -q -b main )   # has .git, but NO infra remote
+
+set +e
+out3="$(
+  cd "$P3"
+  export MARS_PROJECT_ROOT="$P3"
+  . "$P3/shell_utils.sh"
+  INFRA_PUSH_REQUIRED=1 gitPushInfra 2>&1
+)"
+rc3=$?
+set -e
+
+if [[ $rc3 -ne 0 ]]; then
+  pass "required push: returns non-zero when no remote (no silent success)"
+else
+  fail "required push: silently succeeded with no remote (rc=0) — the issue #143 smell"
+fi
+
+if echo "$out3" | grep -q "ERROR: gitPushInfra"; then
+  pass "required push: emitted a loud ERROR"
+else
+  fail "required push: no loud ERROR emitted. Output: $out3"
+fi
+
+# Default (non-required) callers stay lenient: skip + exit 0.
+set +e
+out3b="$(
+  cd "$P3"
+  export MARS_PROJECT_ROOT="$P3"
+  . "$P3/shell_utils.sh"
+  gitPushInfra 2>&1
+)"
+rc3b=$?
+set -e
+
+if [[ $rc3b -eq 0 ]] && echo "$out3b" | grep -q "Skipping gitPushInfra"; then
+  pass "default push: stays lenient (skip + exit 0) for standalone push.sh callers"
+else
+  fail "default push: expected lenient skip+exit0. rc=$rc3b output=$out3b"
+fi
+
+# ===========================================================================
+echo ""
+echo "Test 4: ensure_infra_remote warns loudly when repo_clone_ssh_url empty..."
+
+set +e
+out4="$(
+  cd "$P3"
+  export MARS_PROJECT_ROOT="$P3"
+  . "$P3/shell_utils.sh"
+  ensure_infra_remote 2>&1
+)"
+set -e
+
+if echo "$out4" | grep -q "WARNING: repo_clone_ssh_url is empty"; then
+  pass "ensure_infra_remote: emits a loud WARNING when url missing"
+else
+  fail "ensure_infra_remote: no WARNING when url missing. Output: $out4"
+fi
+
+# ===========================================================================
+echo ""
+echo "Test 5: persistInfra is a benign no-op for a stage with no .git..."
+
+P5="$WORKDIR/p5"   # no .git at all
+mkdir -p "$P5/tf/auto-vars" "$P5/ansible/inventories/default/group_vars/all"
+echo "environment: test" > "$P5/ansible/inventories/default/group_vars/all/env.yaml"
+echo '{}' > "$P5/tf/auto-vars/common.auto.tfvars.json"
+cp "$REPO_ROOT/shell_utils.sh" "$P5/shell_utils.sh"
+
+set +e
+out5="$(
+  cd "$P5"
+  export MARS_PROJECT_ROOT="$P5"
+  . "$P5/shell_utils.sh"
+  persistInfra 2>&1
+)"
+rc5=$?
+set -e
+
+if [[ $rc5 -eq 0 ]] && echo "$out5" | grep -q "WARNING: persistInfra: no .git"; then
+  pass "persistInfra: no-.git stage warns and exits 0 (doesn't break bootstrap stages)"
+else
+  fail "persistInfra: expected warn + exit 0 for no-.git stage. rc=$rc5 output=$out5"
+fi
+
+# --- Summary ---------------------------------------------------------------
+echo ""
+echo "================================"
+echo "  $PASS passed, $FAIL failed"
+echo "================================"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-infra-push.sh
+++ b/tests/test-infra-push.sh
@@ -125,7 +125,7 @@ out1="$(
   cd "$P1"
   export MARS_PROJECT_ROOT="$P1"
   . "$P1/shell_utils.sh"
-  persistInfra "test: apply" 2>&1
+  persistInfra custom-stack-provision "test: apply" 2>&1
 )"
 rc1=$?
 set -e
@@ -268,7 +268,7 @@ fi
 
 # ===========================================================================
 echo ""
-echo "Test 5: persistInfra is a benign no-op for a stage with no .git..."
+echo "Test 5: persistInfra is a benign no-op for a BOOTSTRAP stage with no .git..."
 
 P5="$WORKDIR/p5"   # no .git at all
 mkdir -p "$P5/tf/auto-vars" "$P5/ansible/inventories/default/group_vars/all"
@@ -281,15 +281,45 @@ out5="$(
   cd "$P5"
   export MARS_PROJECT_ROOT="$P5"
   . "$P5/shell_utils.sh"
-  persistInfra 2>&1
+  persistInfra cloud-provision 2>&1
 )"
 rc5=$?
 set -e
 
 if [[ $rc5 -eq 0 ]] && echo "$out5" | grep -q "WARNING: persistInfra: no .git"; then
-  pass "persistInfra: no-.git stage warns and exits 0 (doesn't break bootstrap stages)"
+  pass "persistInfra: no-.git bootstrap stage warns and exits 0 (doesn't break cloud-provision)"
 else
-  fail "persistInfra: expected warn + exit 0 for no-.git stage. rc=$rc5 output=$out5"
+  fail "persistInfra: expected warn + exit 0 for no-.git bootstrap stage. rc=$rc5 output=$out5"
+fi
+
+# ===========================================================================
+echo ""
+echo "Test 6: persistInfra HARD-FAILS when the customer stage has no .git..."
+# Codex P1: if prepare-custom-stack.sh's infra clone failed (or repo_clone_ssh_url
+# was empty), custom-stack-provision could apply terraform, warn, exit success,
+# and leave <project>-infra empty — the original issue #143 bug class. The
+# required stage must fail the deploy instead of silently skipping.
+
+set +e
+out6="$(
+  cd "$P5"
+  export MARS_PROJECT_ROOT="$P5"
+  . "$P5/shell_utils.sh"
+  persistInfra custom-stack-provision 2>&1
+)"
+rc6=$?
+set -e
+
+if [[ $rc6 -ne 0 ]]; then
+  pass "persistInfra: required stage with no .git returns non-zero (fails the deploy, not silent)"
+else
+  fail "persistInfra: required stage with no .git SILENTLY succeeded (rc=0) — issue #143 bug class. Output: $out6"
+fi
+
+if echo "$out6" | grep -q "ERROR: persistInfra: no .git"; then
+  pass "persistInfra: required stage with no .git emits a loud ERROR"
+else
+  fail "persistInfra: required stage missing loud ERROR. Output: $out6"
 fi
 
 # --- Summary ---------------------------------------------------------------

--- a/tf/apply-with-outputs.sh
+++ b/tf/apply-with-outputs.sh
@@ -85,6 +85,13 @@ if [[ "$check_drift" == "true" ]]; then
 
   terraform apply -input=false apply.tfplan
   captureOutputs
+
+  # Persist the applied stack back to the <project>-infra repo. Oracle/ui-core
+  # drives deploys through this drift-check path (NOT tf/apply.sh), so this is
+  # the only place the commit/push actually runs in production. Without it the
+  # infra repo is created but never populated (issue #143). persistInfra is
+  # loud-on-failure: a missing remote/.git fails rather than silently no-ops.
+  persistInfra
 else
   # Simple mode: delegate to apply.sh (includes git merge/commit/push)
   bash "$SCRIPT_DIR/apply.sh" "$lifecycle"

--- a/tf/apply-with-outputs.sh
+++ b/tf/apply-with-outputs.sh
@@ -89,9 +89,10 @@ if [[ "$check_drift" == "true" ]]; then
   # Persist the applied stack back to the <project>-infra repo. Oracle/ui-core
   # drives deploys through this drift-check path (NOT tf/apply.sh), so this is
   # the only place the commit/push actually runs in production. Without it the
-  # infra repo is created but never populated (issue #143). persistInfra is
-  # loud-on-failure: a missing remote/.git fails rather than silently no-ops.
-  persistInfra
+  # infra repo is created but never populated (issue #143). Pass the lifecycle
+  # so persistInfra hard-fails (not silently skips) if the customer stage has
+  # no .git to push. persistInfra is loud-on-failure throughout.
+  persistInfra "$lifecycle"
 else
   # Simple mode: delegate to apply.sh (includes git merge/commit/push)
   bash "$SCRIPT_DIR/apply.sh" "$lifecycle"

--- a/tf/apply.sh
+++ b/tf/apply.sh
@@ -9,8 +9,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 logTemplateVersion
 logPresetsVersion
 
-gitMergeInfraMain
 tfInit
 tfApply
-gitCommit
-gitPushInfra
+# persistInfra = gitMergeInfraMain + gitCommit + (required) gitPushInfra.
+# Hardened over a bare gitCommit/gitPushInfra so a missing infra remote is a
+# LOUD failure instead of a silent no-op that leaves <project>-infra empty
+# (issue #143).
+persistInfra

--- a/tf/apply.sh
+++ b/tf/apply.sh
@@ -14,5 +14,7 @@ tfApply
 # persistInfra = gitMergeInfraMain + gitCommit + (required) gitPushInfra.
 # Hardened over a bare gitCommit/gitPushInfra so a missing infra remote is a
 # LOUD failure instead of a silent no-op that leaves <project>-infra empty
-# (issue #143).
-persistInfra
+# (issue #143). $workspace (= the lifecycle/stage) is set by the sourced
+# utils.sh; pass it so persistInfra hard-fails when the customer stage can't
+# persist rather than silently skipping.
+persistInfra "${workspace:-}"


### PR DESCRIPTION
## Summary

Every deploy provisions a private `<short_project_id>-infra` GitHub repo and invites the deploying user, but the repo was **never populated** — 0/89 `*-infra` repos are non-empty, including 96 projects with `JOB_STATUS_SUCCESS` applies. Customers get invited to an empty repo.

**Confirmed root cause** (verified against staging mars logs): the commit+push is wired only in `tf/apply.sh` (`gitMergeInfraMain → tfInit → tfApply → gitCommit → gitPushInfra`). But Oracle/ui-core drives every stage through `tf/apply-with-outputs.sh --check-drift`, whose drift-check branch runs terraform directly with **zero git operations**. `apply.sh` — the only caller of `gitPushInfra` — is never executed in the production deploy flow, so the push is effectively dead code. Two retrievable full apply logs (cloud-provision `ccs-2fea1f63-r4wfm` and custom-stack `ccs-2fea1f63-47nfs`) both show `setupCloudEnv → init → apply → captureOutputs` with no push activity, matching the empirical 0/89.

The skip was also silent: `gitPushInfra`/`ensure_infra_remote`/`configure_git` returned 0 (or warned only with an emoji) when the remote/`.git` was missing.

## What changed

- Add `persistInfra()` in `shell_utils.sh`: merge `infra/main` (no-op on a new repo), commit, then push with `INFRA_PUSH_REQUIRED=1` so a missing remote is a **loud, non-zero failure** instead of a silent no-op.
- Call `persistInfra "$lifecycle"` in `tf/apply-with-outputs.sh`'s drift-check branch after a successful apply — the real production deploy path — so the push lands. Route `tf/apply.sh` through it too.
- `persistInfra` is **stage-aware**: on the customer stage (`custom-stack-provision`) a missing `.git` is a hard ERROR that fails the deploy (it would otherwise leave the repo empty — the original bug class); bootstrap stages (cloud-provision) warn and skip cleanly.
- `gitPushInfra` checks the `git push` result explicitly (doesn't rely on the caller's `set -e`); `ensure_infra_remote`/`configure_git` WARN visibly to stderr when the remote/`.git` is missing.

## Review

- /review (xhigh): no surviving P0/P1/P2/P3.
- **Codex rescue review** surfaced one P1 (custom-stack could still silently leave the repo empty if `.git` was never established) and one P2 (`gitPushInfra` relied on caller `set -e`). **Both addressed** in commit 2 — see the stage-aware hard-fail and explicit push-result check above; added Test 6 covering the P1.

## Test plan

- [x] `bash tests/test-infra-push.sh` — regression suite using a real local bare repo as the `infra` remote; asserts empty → populated via `persistInfra` and via `apply-with-outputs.sh --check-drift`, plus loud-failure and stage-aware hard-fail. **14/0 with the fix; 4/10 against pre-fix code.**
- [x] `tests/test-apply-scripts.sh` (63/0), `tests/test-prepare-custom-stack.sh` (42/0), `tests/test-plan-all.sh` (56/0) — no regressions.
- [x] `shellcheck -x -S warning` clean; verified the production drift-check path for `custom-stack-provision` with no `.git` exits non-zero (deploy fails) instead of silently succeeding.
- Wired `test-infra-push.sh` and `test-apply-scripts.sh` into CI's `tests` job.

## Follow-up (separate repos, after this merges)

- Bump `SandboxTemplateRef` in reliable (`internal/agentapi/tf_start.go`, currently pinned at `08734c4c`) and ui-core so the deploy flow picks up this fix.
- Backfilling/re-pushing the existing 89 empty repos is a separate task.

Closes #143
Umbrella investigation: luthersystems/reliable#1474