### PR TITLE
Add fail-fast GCP/AWS bootstrap permission preflights (reliable#2243)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -142,3 +142,4 @@ jobs:
           bash tests/test-state-backend-output-parity.sh
           bash tests/test-plan-all.sh
           bash tests/test-gcp-preflight.sh
+          bash tests/test-aws-preflight.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -143,3 +143,4 @@ jobs:
           bash tests/test-plan-all.sh
           bash tests/test-gcp-preflight.sh
           bash tests/test-aws-preflight.sh
+          bash tests/test-destroy-preflight-skip.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -141,3 +141,4 @@ jobs:
           bash tests/test-external-id.sh
           bash tests/test-state-backend-output-parity.sh
           bash tests/test-plan-all.sh
+          bash tests/test-gcp-preflight.sh

--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -405,6 +405,24 @@ setupCloudEnv() {
       echo "  GOOGLE_PROJECT=$GOOGLE_PROJECT"
       echo "  GOOGLE_REGION=$GOOGLE_REGION"
       echo "  GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS"
+
+      # Fail-fast GCP bootstrap-permission preflight (luthersystems/reliable#2243).
+      # Only the cloud-provision stage creates the GCS tfstate bucket + the two
+      # service accounts + the Owner grant, so scope the check to that stage
+      # dir — every other stage is left untouched. CWD is the stage dir here
+      # (setupCloudEnv already assumes this via _selectCloudFiles), so gate on
+      # its basename. The preflight runs BEFORE any terraform init/plan/apply
+      # (this is the earliest hook where GOOGLE_APPLICATION_CREDENTIALS is set),
+      # so a missing-permission failure aborts before repo.tf's GitHub side
+      # creates the orphaned partial state #2243 was about. gcp-preflight.sh
+      # fails OPEN on its own infra/transport errors and only fails CLOSED
+      # (exit 1) on a definitive verdict.
+      if [[ "$(basename "$PWD")" == "cloud-provision" ]]; then
+        if ! bash "$MARS_PROJECT_ROOT/tf/gcp-preflight.sh" "$GOOGLE_PROJECT"; then
+          echo_error "ERROR: GCP bootstrap permission preflight failed — aborting before terraform runs. [reliable#2243]"
+          return 1
+        fi
+      fi
       ;;
 
     aws)

--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -430,6 +430,36 @@ setupCloudEnv() {
       # No GCP provider or credentials needed — all cloud-specific resources
       # and providers are isolated in .tf.tmpl template files.
       echo "AWS environment: using IRSA"
+
+      # Fail-fast AWS bootstrap-permission preflight (luthersystems/reliable#2243).
+      # Twin of the GCP preflight above. Only the cloud-provision stage creates
+      # the S3 tfstate bucket + KMS key + the admin/inspector IAM roles, so scope
+      # the check to that stage dir — every other stage is left untouched. CWD is
+      # the stage dir here. The preflight runs BEFORE any terraform init/plan/apply
+      # so a denied-action failure aborts before repo.tf's GitHub side creates the
+      # orphaned partial state #2243 was about. providers-aws.tf.tmpl has the aws
+      # provider assume the customer bootstrap_role (with aws_external_id), so pass
+      # those from tfvars — the preflight assumes that role and simulates against
+      # it (empty bootstrap_role ⇒ it simulates the ambient caller identity).
+      # aws-preflight.sh fails OPEN on its own infra/transport errors (incl. an
+      # inability to run the simulation) and only fails CLOSED on a definitive
+      # denied-action verdict or an explicit AccessDenied on the assume-role.
+      # NOTE: assumeJumpRole runs after this case; in the mars/Argo deploy path
+      # JUMP_ROLE_ARN is unset, so the ambient (IRSA) creds the preflight uses to
+      # assume bootstrap_role match those terraform will use.
+      if [[ "$(basename "$PWD")" == "cloud-provision" ]]; then
+        local aws_bootstrap_role aws_external_id aws_region_v
+        aws_bootstrap_role=$(getTfVar "bootstrap_role")
+        aws_external_id=$(getTfVar "aws_external_id")
+        aws_region_v=$(getTfVar "aws_region")
+        if ! AWS_BOOTSTRAP_ROLE="$aws_bootstrap_role" \
+             AWS_EXTERNAL_ID="$aws_external_id" \
+             AWS_PREFLIGHT_REGION="${aws_region_v:-us-east-1}" \
+             bash "$MARS_PROJECT_ROOT/tf/aws-preflight.sh" "$aws_bootstrap_role"; then
+          echo_error "ERROR: AWS bootstrap permission preflight failed — aborting before terraform runs. [reliable#2243]"
+          return 1
+        fi
+      fi
       ;;
 
     *)

--- a/tests/test-aws-preflight.sh
+++ b/tests/test-aws-preflight.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Unit tests for tf/aws-preflight.sh — the fail-fast AWS bootstrap-permission
+# preflight (luthersystems/reliable#2243). Twin of tests/test-gcp-preflight.sh.
+#
+# Exercises the assume-role classification + simulate comparison / exit-code
+# logic via the AWS_PREFLIGHT_TEST_* seams (no real AWS access, no
+# credentials). Follows the pass/fail counter pattern of the GCP test.
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREFLIGHT="$SCRIPT_DIR/tf/aws-preflight.sh"
+
+WORKDIR="$(mktemp -d /tmp/test-aws-preflight-XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# A representative customer bootstrap role ARN to simulate against (role mode).
+ROLE="arn:aws:iam::123456789012:role/insideout-bootstrap"
+
+# Full required set — must stay in sync with REQUIRED_ACTIONS in the script AND
+# with reliable bootstrap_permissions.go::bootstrapAWSIAMActions() (drift guard
+# below cross-checks the script against this literal).
+ALL_ACTIONS='["iam:AttachRolePolicy","iam:CreatePolicy","iam:CreateRole","iam:GetRole","iam:PassRole","iam:PutRolePolicy","iam:TagRole","kms:CreateAlias","kms:CreateKey","kms:DescribeKey","kms:PutKeyPolicy","kms:TagResource","s3:CreateBucket","s3:GetBucketVersioning","s3:PutBucketPolicy","s3:PutBucketPublicAccessBlock","s3:PutBucketVersioning","s3:PutEncryptionConfiguration","sts:AssumeRole","sts:GetCallerIdentity"]'
+
+# simulate_response <jq-decision-expr> — emit an `aws iam simulate-principal-policy`
+# shaped JSON where each required action's EvalDecision is computed by the jq
+# expression (with `.` bound to the action name).
+simulate_response() {
+  jq -c "{EvaluationResults: [ .[] | {EvalActionName: ., EvalDecision: ($1)} ]}" <<<"$ALL_ACTIONS"
+}
+
+# run_preflight <expected_exit> <label> <role-arg> -- [extra env assignments...]
+# writes combined output to $OUT and asserts the exit code. Runs under
+# `set -uo pipefail` (no -e), so a non-zero preflight exit does not abort the
+# harness — we capture $? explicitly.
+OUT=""
+run_preflight() {
+  local expected="$1" label="$2" role_arg="$3"
+  shift 3
+  OUT="$(env "$@" bash "$PREFLIGHT" "$role_arg" 2>&1)"
+  local rc=$?
+  if [[ "$rc" -eq "$expected" ]]; then
+    pass "$label (exit $rc)"
+  else
+    fail "$label (expected exit $expected, got $rc)"
+    echo "----- output -----"; echo "$OUT"; echo "------------------"
+  fi
+}
+
+echo "Test 1: all actions allowed (role mode) -> PASS (exit 0)"
+resp_all="$WORKDIR/resp_all.json"
+simulate_response '"allowed"' > "$resp_all"
+run_preflight 0 "all actions allowed" "$ROLE" \
+  "AWS_PREFLIGHT_TEST_SIMULATE_FILE=$resp_all"
+
+echo ""
+echo "Test 2: create actions denied -> FAIL CLOSED (exit 1)"
+resp_denied="$WORKDIR/resp_denied.json"
+# Everything allowed EXCEPT the two representative create actions.
+simulate_response 'if (. == "s3:CreateBucket" or . == "iam:CreateRole") then "implicitDeny" else "allowed" end' > "$resp_denied"
+run_preflight 1 "denied create actions fail closed" "$ROLE" \
+  "AWS_PREFLIGHT_TEST_SIMULATE_FILE=$resp_denied"
+if grep -q "s3:CreateBucket" <<<"$OUT" && grep -q "iam:CreateRole" <<<"$OUT"; then
+  pass "error names both denied create actions"
+else
+  fail "error should name s3:CreateBucket and iam:CreateRole"
+fi
+if grep -q "AdministratorAccess" <<<"$OUT" && grep -q "reliable#2243" <<<"$OUT"; then
+  pass "error includes remediation (AdministratorAccess) + issue ref"
+else
+  fail "error should mention AdministratorAccess and reliable#2243"
+fi
+
+echo ""
+echo "Test 3: empty allowed list -> FAIL CLOSED, all 20 missing (exit 1)"
+resp_empty="$WORKDIR/resp_empty.json"
+echo '{"EvaluationResults": []}' > "$resp_empty"
+run_preflight 1 "zero allowed fails closed" "$ROLE" \
+  "AWS_PREFLIGHT_TEST_SIMULATE_FILE=$resp_empty"
+missing_lines="$(grep -c '^\[aws-preflight\]   - ' <<<"$OUT")"
+if [[ "$missing_lines" -eq 20 ]]; then
+  pass "lists all 20 missing actions"
+else
+  fail "expected 20 missing action lines, got $missing_lines"
+fi
+
+echo ""
+echo "Test 4: simulate call errors -> FAIL OPEN (exit 0)"
+run_preflight 0 "simulate error fails open" "$ROLE" \
+  "AWS_PREFLIGHT_TEST_SIMULATE_FILE=$resp_all" "AWS_PREFLIGHT_TEST_SIMULATE_RC=255"
+if grep -qi "WARNING" <<<"$OUT" && grep -qi "SimulatePrincipalPolicy call failed" <<<"$OUT"; then
+  pass "fail-open logs a warning naming the simulate failure"
+else
+  fail "fail-open should warn about the simulate failure"
+fi
+
+echo ""
+echo "Test 5: assume-role AccessDenied -> FAIL CLOSED, distinct message (exit 1)"
+run_preflight 1 "assume AccessDenied fails closed" "$ROLE" \
+  "AWS_PREFLIGHT_TEST_ASSUME_RC=255" \
+  "AWS_PREFLIGHT_TEST_ASSUME_ERR=An error occurred (AccessDenied) when calling the AssumeRole operation: User is not authorized to perform: sts:AssumeRole on resource"
+if grep -q "could not assume bootstrap role" <<<"$OUT" && grep -q "TRUST-POLICY" <<<"$OUT"; then
+  pass "distinct trust-policy/external-id message (not a missing-permission block)"
+else
+  fail "assume-denied should print the distinct trust-policy/external-id message"
+fi
+# It must NOT be misreported as a missing-action verdict.
+if grep -q "missing .* required IAM action" <<<"$OUT"; then
+  fail "assume-denied must not be reported as a missing-action verdict"
+else
+  pass "assume-denied not conflated with the missing-action verdict"
+fi
+
+echo ""
+echo "Test 6: assume-role transient failure -> FAIL OPEN (exit 0)"
+run_preflight 0 "assume transient fails open" "$ROLE" \
+  "AWS_PREFLIGHT_TEST_ASSUME_RC=255" \
+  "AWS_PREFLIGHT_TEST_ASSUME_ERR=Throttling: Rate exceeded"
+if grep -qi "WARNING" <<<"$OUT" && grep -qi "transient" <<<"$OUT"; then
+  pass "transient assume failure warns and continues"
+else
+  fail "transient assume failure should fail open with a warning"
+fi
+
+echo ""
+echo "Test 7: ambient-caller mode (empty bootstrap role) -> PASS (exit 0)"
+# Empty role arg drives the ambient-identity branch; the simulate seam still
+# supplies the verdict, so all-allowed passes.
+run_preflight 0 "ambient mode all allowed" "" \
+  "AWS_PREFLIGHT_TEST_SIMULATE_FILE=$resp_all"
+
+echo ""
+echo "Test 8: SKIP_AWS_BOOTSTRAP_PREFLIGHT=1 -> SKIP (exit 0)"
+run_preflight 0 "skip switch honored" "$ROLE" \
+  "SKIP_AWS_BOOTSTRAP_PREFLIGHT=1" "AWS_PREFLIGHT_TEST_SIMULATE_FILE=$resp_empty"
+if grep -q "skipping AWS bootstrap permission preflight" <<<"$OUT"; then
+  pass "skip switch logs a notice"
+else
+  fail "skip switch should log a notice"
+fi
+
+echo ""
+echo "Test 9: unparseable simulate body -> FAIL OPEN (exit 0)"
+resp_garbage="$WORKDIR/resp_garbage.json"
+echo 'not-json-at-all' > "$resp_garbage"
+run_preflight 0 "unparseable body fails open" "$ROLE" \
+  "AWS_PREFLIGHT_TEST_SIMULATE_FILE=$resp_garbage"
+
+echo ""
+echo "Test 10: required list in script matches the golden set (drift guard)"
+# Cheap cross-check that the script's REQUIRED_ACTIONS array has not drifted
+# from the mirrored reliable bootstrapAWSIAMActions() set. Extract only
+# whole-line array entries (indented service:Action token on its own line) so
+# comment fragments cannot pollute the set.
+script_actions="$(grep -E '^[[:space:]]+(iam|kms|s3|sts):[A-Za-z]+$' "$PREFLIGHT" \
+  | sed 's/^[[:space:]]*//' \
+  | sort -u)"
+golden_actions="$(jq -r '.[]' <<<"$ALL_ACTIONS" | sort -u)"
+if [[ "$script_actions" == "$golden_actions" ]]; then
+  pass "REQUIRED_ACTIONS matches the 20-action golden set"
+else
+  fail "REQUIRED_ACTIONS drifted from golden set"
+  echo "--- script ---"; echo "$script_actions"
+  echo "--- golden ---"; echo "$golden_actions"
+fi
+
+echo ""
+echo "================================"
+echo "  $PASS passed, $FAIL failed"
+echo "================================"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-destroy-preflight-skip.sh
+++ b/tests/test-destroy-preflight-skip.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Regression test for the destroy-path bootstrap-permission preflight skip
+# (luthersystems/reliable#2243 review finding).
+#
+# The fail-fast cloud-provision preflight (setupCloudEnv → {aws,gcp}-preflight.sh)
+# fires on EVERY mars invocation, because run-with-creds.sh ($MARS) calls
+# setupCloudEnv before exec'ing mars and the gate is scoped by stage-dir
+# basename ("cloud-provision"), not by mars subcommand. tfDestroy runs
+# `mars init` (+ the convergence-gate probes) BEFORE `mars destroy`, so without
+# a scoped skip an under-privileged / later-locked-down credential could no
+# longer TEAR DOWN its own orphaned cloud-provision stack — the preflight would
+# fail closed and abort the teardown. destroy.sh exports
+# SKIP_{AWS,GCP}_BOOTSTRAP_PREFLIGHT=1 to suppress the create-permission check
+# on the (delete-only) destroy path.
+#
+# This exercises the REAL path end-to-end — destroy.sh → utils.sh → the real
+# $MARS=run-with-creds.sh → setupCloudEnv → the real aws-preflight.sh — mocking
+# ONLY the mars container binary (via MARS_CONTAINER_ROOT). It drives the
+# preflight into a definitive FAIL-CLOSED verdict via the AWS test seam
+# (AWS_PREFLIGHT_TEST_SIMULATE_FILE), so if the skip regressed the destroy
+# would be blocked and the test would fail. No aws/gcloud binary is invoked
+# (the seam short-circuits the CLI), so it runs on a bare CI runner. Unlike
+# tests/test-tf-destroy-init.sh — which overrides $MARS with a mock AFTER
+# sourcing utils.sh and therefore never reaches run-with-creds.sh/setupCloudEnv
+# — this test keeps the real credential wrapper in the loop.
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+SRC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+WORKDIR="$(mktemp -d /tmp/test-destroy-preflight-XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# --- Build a minimal project tree that shell_utils.sh / utils.sh expect. ---
+PROOT="$WORKDIR/proj"
+mkdir -p "$PROOT/tf/auto-vars" "$PROOT/ansible/inventories/default/group_vars/all"
+echo "environment: test" > "$PROOT/ansible/inventories/default/group_vars/all/env.yaml"
+
+cp "$SRC_ROOT/shell_utils.sh" "$PROOT/shell_utils.sh"
+for f in utils.sh run-with-creds.sh destroy.sh aws-preflight.sh gcp-preflight.sh; do
+  cp "$SRC_ROOT/tf/$f" "$PROOT/tf/$f"
+done
+chmod +x "$PROOT/tf/"*.sh
+
+# AWS mode with a bootstrap role configured (drives the aws-preflight role path).
+cat > "$PROOT/tf/auto-vars/common.auto.tfvars.json" <<'JSON'
+{"cloud_provider":"aws","bootstrap_role":"arn:aws:iam::123456789012:role/insideout-bootstrap","aws_external_id":"ext-abc","aws_region":"us-east-1"}
+JSON
+
+# Mock the mars container binary. Answers `apply --help` (legacy: no
+# --forbid-resource-changes advertised) and logs every real invocation.
+MARSROOT="$WORKDIR/marsroot"
+mkdir -p "$MARSROOT"
+MARS_LOG="$WORKDIR/mars-calls.log"
+: > "$MARS_LOG"
+cat > "$MARSROOT/mars" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"--help"* ]]; then
+  echo "Usage: mars <env> apply [flags]"
+  exit 0
+fi
+echo "\$*" >> "$MARS_LOG"
+exit 0
+EOF
+chmod +x "$MARSROOT/mars"
+
+# A denied simulate verdict — if the preflight is NOT skipped it fails closed.
+DENIED="$WORKDIR/denied.json"
+echo '{"EvaluationResults":[{"EvalActionName":"s3:CreateBucket","EvalDecision":"implicitDeny"}]}' > "$DENIED"
+
+# ============================================================================
+echo "Test 1: destroy.sh cloud-provision is NOT blocked by the preflight"
+# ============================================================================
+# Run the real destroy.sh from tf/ (so `. ./utils.sh` resolves). The denied
+# seam would fail the preflight closed if it ran — the skip must prevent that.
+out="$(cd "$PROOT/tf" && MARS_PROJECT_ROOT="$PROOT" \
+  MARS_CONTAINER_ROOT="$MARSROOT" \
+  AWS_PREFLIGHT_TEST_SIMULATE_FILE="$DENIED" \
+  bash "$PROOT/tf/destroy.sh" cloud-provision 2>&1)"
+rc=$?
+
+if [[ "$rc" -eq 0 ]]; then
+  pass "destroy.sh exits 0 despite the denied bootstrap-permission verdict"
+else
+  fail "destroy.sh should exit 0 (preflight skipped on destroy), got $rc"
+  echo "----- output -----"; echo "$out"; echo "------------------"
+fi
+
+if grep -q "skipping AWS bootstrap permission preflight" <<<"$out"; then
+  pass "the AWS preflight ran and honored SKIP_AWS_BOOTSTRAP_PREFLIGHT=1"
+else
+  fail "expected the preflight-skip notice (skip may not be wired into destroy.sh)"
+  echo "----- output -----"; echo "$out"; echo "------------------"
+fi
+
+if grep -qi "AWS BOOTSTRAP PREFLIGHT FAILED" <<<"$out"; then
+  fail "destroy was blocked by a fail-closed preflight verdict"
+else
+  pass "no fail-closed verdict surfaced on the destroy path"
+fi
+
+if grep -q "destroy --approve" "$MARS_LOG"; then
+  pass "mars reached 'destroy --approve' (teardown proceeded)"
+else
+  fail "mars never reached destroy — teardown was aborted"
+  echo "----- mars calls -----"; cat "$MARS_LOG"; echo "----------------------"
+fi
+
+# ============================================================================
+echo ""
+echo "Test 2: scope control — the guard STILL fails closed off the destroy path"
+# ============================================================================
+# Invoke the real $MARS wrapper (run-with-creds.sh) directly from a
+# cloud-provision-named workspace dir with the SAME denied seam and NO skip
+# var. This is exactly what tfInit/tfApply do on the apply path — it must
+# still fail closed, proving the skip is scoped to destroy and did not neuter
+# the preflight for real applies.
+WS="$PROOT/tf/cloud-provision"
+mkdir -p "$WS"
+: > "$MARS_LOG"
+out2="$(cd "$WS" && MARS_PROJECT_ROOT="$PROOT" \
+  MARS_CONTAINER_ROOT="$MARSROOT" \
+  AWS_PREFLIGHT_TEST_SIMULATE_FILE="$DENIED" \
+  bash "$PROOT/tf/run-with-creds.sh" default init 2>&1)"
+rc2=$?
+
+if [[ "$rc2" -ne 0 ]]; then
+  pass "run-with-creds.sh (apply-path proxy) fails closed on the denied verdict (exit $rc2)"
+else
+  fail "guard did NOT fire off the destroy path — preflight may be globally disabled"
+  echo "----- output -----"; echo "$out2"; echo "------------------"
+fi
+
+if grep -qi "AWS BOOTSTRAP PREFLIGHT FAILED" <<<"$out2"; then
+  pass "fail-closed verdict surfaced for the non-destroy invocation"
+else
+  fail "expected the fail-closed verdict for the non-destroy invocation"
+  echo "----- output -----"; echo "$out2"; echo "------------------"
+fi
+
+if [[ ! -s "$MARS_LOG" ]]; then
+  pass "mars was NOT invoked (blocked before exec, as intended)"
+else
+  fail "mars was invoked despite the denied verdict off the destroy path"
+  echo "----- mars calls -----"; cat "$MARS_LOG"; echo "----------------------"
+fi
+
+echo ""
+echo "================================"
+echo "  $PASS passed, $FAIL failed"
+echo "================================"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-gcp-preflight.sh
+++ b/tests/test-gcp-preflight.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Unit tests for tf/gcp-preflight.sh — the fail-fast GCP bootstrap-permission
+# preflight (luthersystems/reliable#2243).
+#
+# Exercises the comparison / exit-code logic via the GCP_PREFLIGHT_TEST_*
+# seams (no real GCP access, no credentials). Follows the pass/fail counter
+# pattern of tests/test-external-id.sh.
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREFLIGHT="$SCRIPT_DIR/tf/gcp-preflight.sh"
+
+WORKDIR="$(mktemp -d /tmp/test-gcp-preflight-XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Full required set — must stay in sync with REQUIRED_PERMISSIONS in the script.
+ALL_PERMS='["iam.serviceAccounts.create","iam.serviceAccounts.get","iam.serviceAccounts.getIamPolicy","iam.serviceAccounts.setIamPolicy","resourcemanager.projects.get","resourcemanager.projects.getIamPolicy","resourcemanager.projects.setIamPolicy","storage.buckets.create","storage.buckets.get","storage.buckets.update"]'
+
+# run_preflight <expected_exit> <label> [extra env assignments...] -- writes the
+# combined output to $OUT and asserts the exit code.
+# NOTE: this test runs under `set -uo pipefail` (no -e), so a non-zero exit
+# from the preflight does not abort the harness — we capture $? explicitly.
+OUT=""
+run_preflight() {
+  local expected="$1" label="$2"
+  shift 2
+  OUT="$(env "$@" bash "$PREFLIGHT" test-project-123 2>&1)"
+  local rc=$?
+  if [[ "$rc" -eq "$expected" ]]; then
+    pass "$label (exit $rc)"
+  else
+    fail "$label (expected exit $expected, got $rc)"
+    echo "----- output -----"; echo "$OUT"; echo "------------------"
+  fi
+}
+
+echo "Test 1: all permissions present -> PASS (exit 0)"
+resp_all="$WORKDIR/resp_all.json"
+echo "{\"permissions\": $ALL_PERMS}" > "$resp_all"
+run_preflight 0 "all perms granted" \
+  "GCP_PREFLIGHT_TEST_RESPONSE_FILE=$resp_all" "GCP_PREFLIGHT_TEST_HTTP_CODE=200"
+
+echo ""
+echo "Test 2: missing the two #2243 create perms -> FAIL CLOSED (exit 1)"
+resp_partial="$WORKDIR/resp_partial.json"
+# Everything EXCEPT storage.buckets.create and iam.serviceAccounts.create.
+echo '{"permissions": ["iam.serviceAccounts.get","iam.serviceAccounts.getIamPolicy","iam.serviceAccounts.setIamPolicy","resourcemanager.projects.get","resourcemanager.projects.getIamPolicy","resourcemanager.projects.setIamPolicy","storage.buckets.get","storage.buckets.update"]}' > "$resp_partial"
+run_preflight 1 "missing create perms fails closed" \
+  "GCP_PREFLIGHT_TEST_RESPONSE_FILE=$resp_partial" "GCP_PREFLIGHT_TEST_HTTP_CODE=200"
+if grep -q "storage.buckets.create" <<<"$OUT" && grep -q "iam.serviceAccounts.create" <<<"$OUT"; then
+  pass "error names both missing #2243 permissions"
+else
+  fail "error should name storage.buckets.create and iam.serviceAccounts.create"
+fi
+if grep -q "roles/owner" <<<"$OUT" && grep -q "reliable#2243" <<<"$OUT"; then
+  pass "error includes remediation (roles/owner) + issue ref"
+else
+  fail "error should mention roles/owner and reliable#2243"
+fi
+
+echo ""
+echo "Test 3: empty granted list -> FAIL CLOSED, all 10 missing (exit 1)"
+resp_empty="$WORKDIR/resp_empty.json"
+echo '{"permissions": []}' > "$resp_empty"
+run_preflight 1 "zero perms fails closed" \
+  "GCP_PREFLIGHT_TEST_RESPONSE_FILE=$resp_empty" "GCP_PREFLIGHT_TEST_HTTP_CODE=200"
+if [[ "$(grep -c '^\[gcp-preflight\]   - ' <<<"$OUT")" -eq 10 ]]; then
+  pass "lists all 10 missing permissions"
+else
+  fail "expected 10 missing permission lines, got $(grep -c '^\[gcp-preflight\]   - ' <<<"$OUT")"
+fi
+
+echo ""
+echo "Test 4: HTTP 500 -> FAIL OPEN (exit 0)"
+run_preflight 0 "HTTP 500 fails open" \
+  "GCP_PREFLIGHT_TEST_RESPONSE_FILE=$resp_empty" "GCP_PREFLIGHT_TEST_HTTP_CODE=500"
+if grep -qi "WARNING" <<<"$OUT" && grep -q "HTTP 500" <<<"$OUT"; then
+  pass "fail-open logs a warning naming the HTTP status"
+else
+  fail "fail-open should warn and name HTTP 500"
+fi
+
+echo ""
+echo "Test 5: HTTP 403 -> FAIL OPEN (not a definitive verdict) (exit 0)"
+run_preflight 0 "HTTP 403 fails open" \
+  "GCP_PREFLIGHT_TEST_RESPONSE_FILE=$resp_all" "GCP_PREFLIGHT_TEST_HTTP_CODE=403"
+
+echo ""
+echo "Test 6: unparseable 200 body -> FAIL OPEN (exit 0)"
+resp_garbage="$WORKDIR/resp_garbage.json"
+echo 'not-json-at-all' > "$resp_garbage"
+run_preflight 0 "unparseable 200 fails open" \
+  "GCP_PREFLIGHT_TEST_RESPONSE_FILE=$resp_garbage" "GCP_PREFLIGHT_TEST_HTTP_CODE=200"
+
+echo ""
+echo "Test 7: SKIP_GCP_BOOTSTRAP_PREFLIGHT=1 -> SKIP (exit 0)"
+run_preflight 0 "skip switch honored" \
+  "SKIP_GCP_BOOTSTRAP_PREFLIGHT=1" "GCP_PREFLIGHT_TEST_RESPONSE_FILE=$resp_empty" "GCP_PREFLIGHT_TEST_HTTP_CODE=200"
+if grep -q "skipping GCP bootstrap permission preflight" <<<"$OUT"; then
+  pass "skip switch logs a notice"
+else
+  fail "skip switch should log a notice"
+fi
+
+echo ""
+echo "Test 8: no project id + no test seam -> FAIL OPEN (exit 0)"
+set +e
+OUT="$(env -u GOOGLE_PROJECT -u GCP_PROJECT_ID -u GOOGLE_APPLICATION_CREDENTIALS bash "$PREFLIGHT" 2>&1)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  pass "missing project id fails open (exit 0)"
+else
+  fail "missing project id should fail open (got exit $rc)"
+fi
+
+echo ""
+echo "Test 9: required list in script matches the golden set (drift guard)"
+# Cheap cross-check that the script's REQUIRED_PERMISSIONS array has not
+# drifted from the mirrored reliable bootstrapGCPIAMPermissions() set. Extract
+# only whole-line array entries (indented token on its own line) so comment
+# fragments like "storage.buckets.{create,get,update}" cannot pollute the set.
+script_perms="$(grep -E '^[[:space:]]+(iam\.serviceAccounts|resourcemanager\.projects|storage\.buckets)\.[a-zA-Z]+$' "$PREFLIGHT" \
+  | sed 's/^[[:space:]]*//' \
+  | sort -u)"
+golden_perms="$(jq -r '.[]' <<<"$ALL_PERMS" | sort -u)"
+if [[ "$script_perms" == "$golden_perms" ]]; then
+  pass "REQUIRED_PERMISSIONS matches the 10-permission golden set"
+else
+  fail "REQUIRED_PERMISSIONS drifted from golden set"
+  echo "--- script ---"; echo "$script_perms"
+  echo "--- golden ---"; echo "$golden_perms"
+fi
+
+echo ""
+echo "================================"
+echo "  $PASS passed, $FAIL failed"
+echo "================================"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tf/aws-preflight.sh
+++ b/tf/aws-preflight.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# aws-preflight.sh — Fail-fast AWS bootstrap-permission preflight.
+#
+# The AWS twin of tf/gcp-preflight.sh. Defense-in-depth guard for
+# luthersystems/reliable#2243 (the Beatloom incident): a customer's
+# under-privileged connecting credential passed credential validation and
+# reached the `cloud-provision` Terraform apply, then 403'd mid-apply on a
+# create action (on GCP it was storage.buckets.create / iam.serviceAccounts
+# .create; the AWS analogue is s3:CreateBucket / iam:CreateRole) — AFTER the
+# GitHub half of that apply (tf/cloud-provision/repo.tf) had already created a
+# repo, deploy key, and Actions variables, leaving orphaned partial state.
+#
+# Upstream (reliable / ui-core) now feed Oracle a bootstrap action list so its
+# plan-time preflight catches this, but the composed archive is driven from
+# MANY caller paths (apply.sh / apply-with-outputs.sh / apply-plan.sh /
+# plan-all.sh, all via setupCloudEnv). This script protects ALL of them from
+# INSIDE the template: it runs BEFORE terraform creates anything and calls
+# iam:SimulatePrincipalPolicy with the exact bootstrap action set, exiting
+# non-zero with an actionable message when actions are denied.
+#
+# The action list below MIRRORS reliable's
+# internal/agentapi/bootstrap_permissions.go :: bootstrapAWSIAMActions()
+# (whose header cites this repo's tf/cloud-provision/aws-resources.tf.tmpl —
+# this citation is the reciprocal). Keep the two lists in sync.
+#
+# s3:CreateBucket and iam:CreateRole are representative of the create actions a
+# plan-only validation (#2243) would never exercise.
+#
+# ---------------------------------------------------------------------------
+# Principal resolution — how the cloud-provision stage actually authenticates.
+#
+# tf/cloud-provision/providers-aws.tf.tmpl declares:
+#
+#   provider "aws" {
+#     assume_role {
+#       role_arn    = var.bootstrap_role
+#       external_id = var.aws_external_id  (when non-empty)
+#     }
+#   }
+#
+# i.e. the ambient (IRSA / mars) credentials assume the customer's
+# `bootstrap_role`, and THAT role is the principal that performs every create.
+# So the faithful preflight is:
+#
+#   * bootstrap_role set  → `aws sts assume-role` it (with external id when
+#     configured) using the ambient credentials, then run
+#     `aws iam simulate-principal-policy --policy-source-arn <bootstrap_role>`
+#     UNDER the assumed-role session credentials, so the customer account's IAM
+#     answers. simulate takes the ROLE identity ARN as the policy source, which
+#     is exactly what bootstrap_role already is.
+#   * bootstrap_role empty → simulate against the ambient caller identity
+#     (`aws sts get-caller-identity` .Arn), first mapping an assumed-role
+#     SESSION arn back to the role IDENTITY arn simulate requires (the classic
+#     gotcha: arn:aws:sts::ACCT:assumed-role/Name/session →
+#     arn:aws:iam::ACCT:role/Name).
+#
+# Owner-parity note: unlike the GCP side, the AWS bootstrap stage does not grant
+# a superuser role to another principal, so there is no AWS analogue of the GCP
+# Owner-grant caveat — a clean simulate verdict is a complete verdict here.
+#
+# ---------------------------------------------------------------------------
+# Semantics (mirrors ui-core aws_iam_preflight.go / aws_bootstrap_iam_preflight.go):
+#   * FAIL CLOSED (exit 1):
+#       - a SUCCESSFUL simulate that returns one or more non-"allowed" actions;
+#       - an explicit AccessDenied on the ASSUME-ROLE itself (a trust-policy /
+#         external-id problem that WILL fail the deploy — actionable, distinct
+#         message).
+#   * FAIL OPEN  (exit 0 + warning): any infrastructure / transport / "cannot
+#     verify" condition — aws CLI absent, a TRANSIENT assume-role failure
+#     (throttling / 5xx / network / expired ambient creds), any error from the
+#     simulate call itself (including the caller lacking
+#     iam:SimulatePrincipalPolicy — inability to verify is NOT proof of
+#     insufficiency, reliable#2243), an unparseable body. The preflight must
+#     NEVER block a deploy on its own flakiness.
+#   * SKIP (exit 0 + notice): SKIP_AWS_BOOTSTRAP_PREFLIGHT=1 operator override.
+#
+# Deliberately does NOT `set -e` (same rationale as gcp-preflight.sh): fail-open
+# depends on catching non-zero exits inline, and an unexpected `set -e` abort
+# would surface as a non-zero exit — which setupCloudEnv treats as fatal — i.e.
+# the exact opposite of fail-open.
+#
+# Never echoes credentials/tokens: assumed-role session secrets are extracted
+# into locals and passed into the simulate call's OWN environment only, never
+# logged.
+#
+# Usage: bash aws-preflight.sh [<bootstrap_role_arn>]
+#   bootstrap role arn resolves from: $1 -> $AWS_BOOTSTRAP_ROLE (empty ⇒
+#     ambient-caller mode)
+#   external id: $AWS_EXTERNAL_ID (optional; confused-deputy protection)
+set -uo pipefail
+
+# ----------------------------------------------------------------------------
+# Required bootstrap actions — mirror of reliable
+# bootstrap_permissions.go::bootstrapAWSIAMActions(). Grounded in
+# tf/cloud-provision/aws-resources.tf.tmpl:
+#   s3:CreateBucket / s3:PutBucket{Versioning,PublicAccessBlock,Policy} /
+#   s3:PutEncryptionConfiguration / s3:GetBucketVersioning
+#                                            module.bootstrap tfstate bucket
+#   kms:CreateKey / kms:CreateAlias / kms:TagResource / kms:PutKeyPolicy /
+#   kms:DescribeKey                          tfstate KMS key + alias
+#   iam:CreateRole / iam:GetRole / iam:TagRole / iam:PutRolePolicy /
+#   iam:AttachRolePolicy / iam:CreatePolicy / iam:PassRole
+#                                            admin terraform role + inspector role
+#   sts:AssumeRole                           admin role assumed by the terraform SA
+#   sts:GetCallerIdentity                    AWS provider init
+# ----------------------------------------------------------------------------
+REQUIRED_ACTIONS=(
+  iam:AttachRolePolicy
+  iam:CreatePolicy
+  iam:CreateRole
+  iam:GetRole
+  iam:PassRole
+  iam:PutRolePolicy
+  iam:TagRole
+  kms:CreateAlias
+  kms:CreateKey
+  kms:DescribeKey
+  kms:PutKeyPolicy
+  kms:TagResource
+  s3:CreateBucket
+  s3:GetBucketVersioning
+  s3:PutBucketPolicy
+  s3:PutBucketPublicAccessBlock
+  s3:PutBucketVersioning
+  s3:PutEncryptionConfiguration
+  sts:AssumeRole
+  sts:GetCallerIdentity
+)
+
+# IAM/STS are global; us-east-1 is the always-reachable control-plane endpoint
+# (matches ui-core's hardcoded us-east-1). Overridable for test flexibility.
+PREFLIGHT_REGION="${AWS_PREFLIGHT_REGION:-us-east-1}"
+
+log() { echo "[aws-preflight] $*"; }
+err() { echo "[aws-preflight] $*" >&2; }
+
+# fail_open <reason> — log a warning and exit 0. Never block a deploy on our
+# own flakiness (tooling, network, throttling, inability to verify).
+fail_open() {
+  err "WARNING: $1"
+  err "WARNING: preflight is advisory — continuing (deploy NOT blocked)."
+  err "WARNING: set SKIP_AWS_BOOTSTRAP_PREFLIGHT=1 to silence this check."
+  exit 0
+}
+
+# Operator escape hatch.
+if [[ "${SKIP_AWS_BOOTSTRAP_PREFLIGHT:-}" == "1" ]]; then
+  log "SKIP_AWS_BOOTSTRAP_PREFLIGHT=1 — skipping AWS bootstrap permission preflight."
+  exit 0
+fi
+
+BOOTSTRAP_ROLE="${1:-${AWS_BOOTSTRAP_ROLE:-}}"
+EXTERNAL_ID="${AWS_EXTERNAL_ID:-}"
+
+# Test mode is active when either simulate output or an assume-role return code
+# is injected. In test mode NO live aws binary is invoked, so the comparison /
+# classification logic can be unit-tested with no cloud access or credentials.
+#   AWS_PREFLIGHT_TEST_SIMULATE_FILE  path to a JSON file shaped like
+#                                     `aws iam simulate-principal-policy` output
+#                                     ({"EvaluationResults":[{EvalActionName,
+#                                     EvalDecision},...]}).
+#   AWS_PREFLIGHT_TEST_SIMULATE_RC    (default 0) non-zero ⇒ simulate call
+#                                     "errored" ⇒ fail-open.
+#   AWS_PREFLIGHT_TEST_ASSUME_RC      (default 0) non-zero ⇒ assume-role
+#                                     "failed"; classified via ASSUME_ERR.
+#   AWS_PREFLIGHT_TEST_ASSUME_ERR     stderr text the failed assume "returned".
+TEST_MODE=0
+if [[ -n "${AWS_PREFLIGHT_TEST_SIMULATE_FILE:-}" || -n "${AWS_PREFLIGHT_TEST_ASSUME_RC:-}" ]]; then
+  TEST_MODE=1
+fi
+
+# classify_assume_failure <stderr-text> — decide fail-closed vs fail-open for a
+# failed sts:assume-role, mirroring ui-core's semantics: an explicit AccessDenied
+# (wrong trust policy or external id) WILL fail the deploy → fail CLOSED with a
+# distinct, actionable message; anything else (throttling, 5xx, network, expired
+# ambient creds) is not evidence of insufficiency → fail OPEN.
+classify_assume_failure() {
+  local errtext="$1"
+  if grep -qiE 'AccessDenied|not authorized to perform:? *sts:assumerole' <<<"$errtext"; then
+    err ""
+    err "================================================================"
+    err "AWS BOOTSTRAP PREFLIGHT FAILED — could not assume bootstrap role"
+    err "${BOOTSTRAP_ROLE}: the assume-role call was explicitly DENIED (AccessDenied)."
+    err ""
+    err "This is a TRUST-POLICY or EXTERNAL-ID problem, not a missing deploy"
+    err "permission. Fix on the customer side:"
+    err "  - the role's trust policy must allow the connecting deployer principal"
+    err "    to sts:AssumeRole it, and"
+    err "  - the external id must match the one configured for this deployment"
+    err "    (aws_external_id)."
+    err "${errtext}"
+    err ""
+    err "Escape hatch: set SKIP_AWS_BOOTSTRAP_PREFLIGHT=1 to bypass this check."
+    err "Ref: luthersystems/reliable#2243."
+    err "================================================================"
+    exit 1
+  fi
+  fail_open "could not assume bootstrap role ${BOOTSTRAP_ROLE} (transient — throttling/5xx/network/expired creds): ${errtext:-<no detail>}"
+}
+
+# ----------------------------------------------------------------------------
+# Phase 1 — resolve the policy-source ARN to simulate, assuming the bootstrap
+# role when one is configured. Populates:
+#   policy_source_arn  the IAM role/user identity ARN simulate evaluates
+#   _AK / _SK / _ST    assumed-role session creds (role mode only; empty in
+#                      ambient mode so simulate uses the ambient env creds)
+# ----------------------------------------------------------------------------
+policy_source_arn=""
+_AK="" _SK="" _ST=""
+
+if [[ -n "$BOOTSTRAP_ROLE" ]]; then
+  # ---- role mode: assume the customer bootstrap role ----
+  policy_source_arn="$BOOTSTRAP_ROLE"
+  log "checking bootstrap actions against role ${BOOTSTRAP_ROLE} (assume-role${EXTERNAL_ID:+ +external-id})"
+
+  if [[ "$TEST_MODE" -eq 1 ]]; then
+    assume_rc="${AWS_PREFLIGHT_TEST_ASSUME_RC:-0}"
+    if [[ "$assume_rc" != "0" ]]; then
+      classify_assume_failure "${AWS_PREFLIGHT_TEST_ASSUME_ERR:-}"
+    fi
+    # else: assume "succeeded"; the simulate seam supplies the verdict below.
+  else
+    if ! command -v aws >/dev/null 2>&1; then
+      fail_open "aws CLI not found on PATH — cannot run the permission simulation."
+    fi
+    assume_err_file="$(mktemp /tmp/aws-preflight-assume-err-XXXXXX 2>/dev/null || echo "")"
+    assume_args=(sts assume-role
+      --role-arn "$BOOTSTRAP_ROLE"
+      --role-session-name "insideout-bootstrap-preflight"
+      --duration-seconds 900
+      --region "$PREFLIGHT_REGION"
+      --output json)
+    if [[ -n "$EXTERNAL_ID" ]]; then
+      assume_args+=(--external-id "$EXTERNAL_ID")
+    fi
+    if ! assume_json="$(aws "${assume_args[@]}" 2>"${assume_err_file:-/dev/null}")"; then
+      assume_err=""
+      if [[ -n "$assume_err_file" && -f "$assume_err_file" ]]; then
+        assume_err="$(cat "$assume_err_file" 2>/dev/null || echo "")"
+      fi
+      rm -f "${assume_err_file:-}" 2>/dev/null || true
+      classify_assume_failure "$assume_err"
+    fi
+    rm -f "${assume_err_file:-}" 2>/dev/null || true
+    # Extract session creds into locals only — never logged.
+    _AK="$(jq -r '.Credentials.AccessKeyId // ""' <<<"$assume_json" 2>/dev/null || echo "")"
+    _SK="$(jq -r '.Credentials.SecretAccessKey // ""' <<<"$assume_json" 2>/dev/null || echo "")"
+    _ST="$(jq -r '.Credentials.SessionToken // ""' <<<"$assume_json" 2>/dev/null || echo "")"
+    if [[ -z "$_AK" || -z "$_SK" || -z "$_ST" ]]; then
+      fail_open "assume-role for ${BOOTSTRAP_ROLE} returned an incomplete credential set (treating as infra/transient)."
+    fi
+  fi
+else
+  # ---- ambient mode: simulate against the caller identity ----
+  if [[ "$TEST_MODE" -eq 1 ]]; then
+    policy_source_arn="arn:aws:iam::000000000000:role/test-ambient-principal"
+  else
+    if ! command -v aws >/dev/null 2>&1; then
+      fail_open "aws CLI not found on PATH — cannot run the permission simulation."
+    fi
+    if ! caller_json="$(aws sts get-caller-identity --region "$PREFLIGHT_REGION" --output json 2>/dev/null)"; then
+      fail_open "sts:GetCallerIdentity failed (no usable ambient credentials / transient)."
+    fi
+    caller_arn="$(jq -r '.Arn // ""' <<<"$caller_json" 2>/dev/null || echo "")"
+    if [[ -z "$caller_arn" ]]; then
+      fail_open "sts:GetCallerIdentity returned an empty ARN (treating as infra/transient)."
+    fi
+    # Map an assumed-role SESSION arn back to the role IDENTITY arn simulate
+    # requires (path-less roles; assumed-role arns carry no role path). IAM
+    # user / role identity arns pass through unchanged.
+    if [[ "$caller_arn" =~ ^arn:([a-z-]+):sts::([0-9]+):assumed-role/([^/]+)/ ]]; then
+      policy_source_arn="arn:${BASH_REMATCH[1]}:iam::${BASH_REMATCH[2]}:role/${BASH_REMATCH[3]}"
+    elif [[ "$caller_arn" =~ ^arn:[a-z-]+:iam::[0-9]+:(user|role)/ ]]; then
+      policy_source_arn="$caller_arn"
+    else
+      fail_open "caller identity ${caller_arn} is not an IAM user/role (federated/root?) — cannot resolve a simulate policy source."
+    fi
+    log "checking bootstrap actions against ambient caller identity ${policy_source_arn}"
+  fi
+fi
+
+# ----------------------------------------------------------------------------
+# Phase 2 — run iam:SimulatePrincipalPolicy (or the test seam) and capture the
+# result body + return code. Any non-zero return from the simulate call itself
+# is fail-open (inability to verify is not proof of insufficiency).
+# ----------------------------------------------------------------------------
+sim_json=""
+sim_rc=0
+sim_err=""
+
+if [[ "$TEST_MODE" -eq 1 ]]; then
+  sim_rc="${AWS_PREFLIGHT_TEST_SIMULATE_RC:-0}"
+  if [[ "$sim_rc" == "0" && -n "${AWS_PREFLIGHT_TEST_SIMULATE_FILE:-}" && -f "$AWS_PREFLIGHT_TEST_SIMULATE_FILE" ]]; then
+    sim_json="$(cat "$AWS_PREFLIGHT_TEST_SIMULATE_FILE")"
+  fi
+  sim_err="injected simulate rc=${sim_rc}"
+  log "test seam active (AWS_PREFLIGHT_TEST_SIMULATE_FILE) simulate_rc=${sim_rc}"
+else
+  sim_err_file="$(mktemp /tmp/aws-preflight-sim-err-XXXXXX 2>/dev/null || echo "")"
+  # Assumed-role session creds (role mode) are injected into the simulate
+  # call's OWN environment only. In ambient mode _AK is empty and the call
+  # inherits the process's ambient credentials.
+  if [[ -n "$_AK" ]]; then
+    sim_json="$(env \
+      AWS_ACCESS_KEY_ID="$_AK" \
+      AWS_SECRET_ACCESS_KEY="$_SK" \
+      AWS_SESSION_TOKEN="$_ST" \
+      aws iam simulate-principal-policy \
+      --region "$PREFLIGHT_REGION" \
+      --policy-source-arn "$policy_source_arn" \
+      --action-names "${REQUIRED_ACTIONS[@]}" \
+      --output json 2>"${sim_err_file:-/dev/null}")" || sim_rc=$?
+  else
+    sim_json="$(aws iam simulate-principal-policy \
+      --region "$PREFLIGHT_REGION" \
+      --policy-source-arn "$policy_source_arn" \
+      --action-names "${REQUIRED_ACTIONS[@]}" \
+      --output json 2>"${sim_err_file:-/dev/null}")" || sim_rc=$?
+  fi
+  if [[ -n "$sim_err_file" && -f "$sim_err_file" ]]; then
+    sim_err="$(cat "$sim_err_file" 2>/dev/null || echo "")"
+    rm -f "$sim_err_file"
+  fi
+fi
+
+if [[ "$sim_rc" != "0" ]]; then
+  # Any simulate error → fail open. Most likely the principal simply lacks
+  # iam:SimulatePrincipalPolicy (reliable#2243: an otherwise-valid restricted
+  # role would 403 here), or AWS was transiently unavailable. Not evidence of
+  # insufficient deploy permissions.
+  fail_open "iam:SimulatePrincipalPolicy call failed (cannot verify — the principal may lack iam:SimulatePrincipalPolicy, or a transient AWS error): ${sim_err:-<no detail>}"
+fi
+
+# ----------------------------------------------------------------------------
+# Phase 3 — interpret the simulate result. Only a parseable body is a verdict.
+# ----------------------------------------------------------------------------
+if ! jq -e . >/dev/null 2>&1 <<<"$sim_json"; then
+  fail_open "simulate returned an unparseable body (treating as infra/transient)."
+fi
+
+# Actions that came back exactly "allowed". Anything required but absent from
+# this set (explicitDeny / implicitDeny / missing) is treated as denied.
+allowed="$(jq -r '.EvaluationResults[]? | select(.EvalDecision=="allowed") | .EvalActionName' <<<"$sim_json" 2>/dev/null || echo "")"
+
+denied=()
+for action in "${REQUIRED_ACTIONS[@]}"; do
+  if ! grep -qxF "$action" <<<"$allowed"; then
+    denied+=("$action")
+  fi
+done
+
+if [[ ${#denied[@]} -eq 0 ]]; then
+  log "OK — principal ${policy_source_arn} is allowed all ${#REQUIRED_ACTIONS[@]} bootstrap actions."
+  exit 0
+fi
+
+# --- fail closed: definitive denied-action verdict ---
+err ""
+err "================================================================"
+err "AWS BOOTSTRAP PREFLIGHT FAILED — the principal"
+err "${policy_source_arn} is missing ${#denied[@]} required IAM action(s):"
+for action in "${denied[@]}"; do
+  err "  - ${action}"
+done
+err ""
+err "Attach the AdministratorAccess managed policy to this principal, or a"
+err "policy granting at minimum the ${#REQUIRED_ACTIONS[@]} bootstrap actions the"
+err "cloud-provision stage needs (the denied ones are listed above), then re-run"
+err "the deploy."
+err ""
+err "Escape hatch: set SKIP_AWS_BOOTSTRAP_PREFLIGHT=1 to bypass this check."
+err "Ref: luthersystems/reliable#2243."
+err "================================================================"
+exit 1

--- a/tf/destroy.sh
+++ b/tf/destroy.sh
@@ -47,6 +47,24 @@ set -- "$lifecycle"
 logTemplateVersion
 logPresetsVersion
 
+# Suppress the cloud-provision bootstrap-permission preflight on the destroy
+# path (luthersystems/reliable#2243). The preflight (setupCloudEnv →
+# {aws,gcp}-preflight.sh) fires on EVERY mars invocation via run-with-creds.sh
+# ($MARS) whenever the stage dir basename is "cloud-provision" — and tfDestroy
+# runs `mars init` (and the convergence-gate `mars apply --help` / `mars apply
+# --forbid-resource-changes`) before `mars destroy`. It checks the CREATE
+# permissions the bootstrap APPLY needs (s3:CreateBucket, iam:CreateRole, …),
+# which a teardown does NOT need. Left unsuppressed, a stack whose connecting
+# credential was later locked down (or was under-privileged and left orphaned
+# partial state — the very #2243 scenario) could no longer be destroyed: the
+# preflight would fail closed and abort the teardown, blocking cleanup. The
+# hook can't cheaply tell a destroy's `init` from an apply's `init` (they are
+# identical mars calls), so we scope the skip here at the destroy entry point.
+# These exports live only in this process and its mars children — apply.sh /
+# plan.sh / drift-refresh.sh run as separate processes and keep the guard.
+export SKIP_AWS_BOOTSTRAP_PREFLIGHT=1
+export SKIP_GCP_BOOTSTRAP_PREFLIGHT=1
+
 tfInit
 if [[ "$ignore_drift" == "true" ]]; then
   tfDestroy --ignore-drift

--- a/tf/gcp-preflight.sh
+++ b/tf/gcp-preflight.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# gcp-preflight.sh — Fail-fast GCP bootstrap-permission preflight.
+#
+# Defense-in-depth guard for luthersystems/reliable#2243 (the Beatloom
+# incident): a customer's under-privileged GCP service account passed
+# credential validation and reached the `cloud-provision` Terraform apply,
+# then 403'd mid-apply on storage.buckets.create / iam.serviceAccounts.create
+# — AFTER the GitHub half of that apply (tf/cloud-provision/repo.tf) had
+# already created a repo, deploy key, and Actions variables, leaving orphaned
+# partial state.
+#
+# Upstream (reliable / ui-core) now feed Oracle a bootstrap permission list so
+# its plan-time preflight catches this, but the composed archive is driven
+# from MANY caller paths (apply.sh / apply-with-outputs.sh / apply-plan.sh /
+# plan-all.sh, all via setupCloudEnv). This script protects ALL of them from
+# INSIDE the template: it runs BEFORE terraform creates anything and calls GCP
+# projects.testIamPermissions with the exact bootstrap permission set, exiting
+# non-zero with an actionable message when permissions are missing.
+#
+# The permission list below MIRRORS reliable's
+# internal/agentapi/bootstrap_permissions.go :: bootstrapGCPIAMPermissions()
+# (whose header cites this repo's tf/cloud-provision/gcp-resources.tf.tmpl —
+# this citation is the reciprocal). Keep the two lists in sync.
+#
+# storage.buckets.create and iam.serviceAccounts.create are the two exact
+# denials from the #2243 incident.
+#
+# Owner-grant caveat: the cloud-provision stage grants roles/owner to the
+# InsideOut management service account
+# (google_project_iam_member.management_owner). GCP only permits a caller to
+# grant Owner if the caller itself holds Owner, and testIamPermissions CANNOT
+# verify that constraint (it reports the caller's own allowed permissions, not
+# whether a given role grant will be permitted). So PASSING this preflight
+# does NOT by itself guarantee the Owner grant will succeed — the remediation
+# message says so and recommends roles/owner.
+#
+# Semantics:
+#   * FAIL CLOSED (exit 1): a definitive 200 verdict with missing permissions,
+#     or a definitive bad-credential rejection at token exchange.
+#   * FAIL OPEN  (exit 0 + warning): any infrastructure/transport error
+#     (gcloud absent, network blip, HTTP 5xx, non-200, unparseable body) —
+#     the preflight must NEVER block a deploy on its own flakiness.
+#   * SKIP (exit 0 + notice): SKIP_GCP_BOOTSTRAP_PREFLIGHT=1 operator override.
+#
+# Deliberately does NOT `set -e`: fail-open depends on catching non-zero exits
+# inline, and an unexpected `set -e` abort would surface as a non-zero exit —
+# which setupCloudEnv treats as fatal — i.e. the exact opposite of fail-open.
+#
+# Usage: bash gcp-preflight.sh [<gcp_project_id>]
+#   project id resolves from: $1 -> $GOOGLE_PROJECT -> $GCP_PROJECT_ID
+#   service-account key path: $GOOGLE_APPLICATION_CREDENTIALS
+set -uo pipefail
+
+# ----------------------------------------------------------------------------
+# Required bootstrap permissions — mirror of reliable
+# bootstrap_permissions.go::bootstrapGCPIAMPermissions(). Grounded in
+# tf/cloud-provision/gcp-resources.tf.tmpl:
+#   storage.buckets.{create,get,update}      google_storage_bucket.tfstate
+#   iam.serviceAccounts.{create,get}         inspector + management SAs
+#   iam.serviceAccounts.{get,set}IamPolicy   the two SA token-creator bindings
+#   resourcemanager.projects.get             provider project read
+#   resourcemanager.projects.{get,set}IamPolicy  the five project IAM bindings
+# ----------------------------------------------------------------------------
+REQUIRED_PERMISSIONS=(
+  iam.serviceAccounts.create
+  iam.serviceAccounts.get
+  iam.serviceAccounts.getIamPolicy
+  iam.serviceAccounts.setIamPolicy
+  resourcemanager.projects.get
+  resourcemanager.projects.getIamPolicy
+  resourcemanager.projects.setIamPolicy
+  storage.buckets.create
+  storage.buckets.get
+  storage.buckets.update
+)
+
+log() { echo "[gcp-preflight] $*"; }
+err() { echo "[gcp-preflight] $*" >&2; }
+
+# fail_open <reason> — log a warning and exit 0. Never block a deploy on our
+# own flakiness (network, tooling, unexpected HTTP status).
+fail_open() {
+  err "WARNING: $1"
+  err "WARNING: preflight is advisory — continuing (deploy NOT blocked)."
+  err "WARNING: set SKIP_GCP_BOOTSTRAP_PREFLIGHT=1 to silence this check."
+  exit 0
+}
+
+# Operator escape hatch.
+if [[ "${SKIP_GCP_BOOTSTRAP_PREFLIGHT:-}" == "1" ]]; then
+  log "SKIP_GCP_BOOTSTRAP_PREFLIGHT=1 — skipping GCP bootstrap permission preflight."
+  exit 0
+fi
+
+PROJECT_ID="${1:-${GOOGLE_PROJECT:-${GCP_PROJECT_ID:-}}}"
+CREDS_FILE="${GOOGLE_APPLICATION_CREDENTIALS:-}"
+
+if [[ -z "$PROJECT_ID" ]]; then
+  fail_open "no GCP project id (arg / GOOGLE_PROJECT / GCP_PROJECT_ID all empty)."
+fi
+
+# Service-account email — best-effort, only used to make the message actionable.
+sa_email="unknown"
+if [[ -n "$CREDS_FILE" && -f "$CREDS_FILE" ]]; then
+  sa_email="$(jq -r '.client_email // "unknown"' "$CREDS_FILE" 2>/dev/null || echo unknown)"
+fi
+
+log "checking bootstrap permissions for service account ${sa_email} on project ${PROJECT_ID}"
+
+# ----------------------------------------------------------------------------
+# Obtain the testIamPermissions response body + HTTP status.
+#
+# Test seam: GCP_PREFLIGHT_TEST_RESPONSE_FILE short-circuits the live GCP call
+# so the comparison logic can be unit-tested with no cloud access. When set,
+# GCP_PREFLIGHT_TEST_HTTP_CODE (default 200) selects the simulated status.
+# ----------------------------------------------------------------------------
+response=""
+http_code=""
+
+if [[ -n "${GCP_PREFLIGHT_TEST_RESPONSE_FILE:-}" ]]; then
+  http_code="${GCP_PREFLIGHT_TEST_HTTP_CODE:-200}"
+  if [[ -f "$GCP_PREFLIGHT_TEST_RESPONSE_FILE" ]]; then
+    response="$(cat "$GCP_PREFLIGHT_TEST_RESPONSE_FILE")"
+  fi
+  log "test seam active (GCP_PREFLIGHT_TEST_RESPONSE_FILE) http_code=${http_code}"
+else
+  # --- live path: mint a token with gcloud, POST testIamPermissions ---
+  if ! command -v gcloud >/dev/null 2>&1; then
+    fail_open "gcloud not found on PATH — cannot mint an access token."
+  fi
+  if [[ -z "$CREDS_FILE" || ! -f "$CREDS_FILE" ]]; then
+    fail_open "GOOGLE_APPLICATION_CREDENTIALS unset or file missing — cannot mint a token."
+  fi
+
+  # Only service_account keys can be activated. setupGCPCredentials already
+  # rejects non-service_account (e.g. WIF external_account) JSONs upstream, but
+  # guard defensively and fail open rather than block if one ever reaches here.
+  cred_type="$(jq -r '.type // ""' "$CREDS_FILE" 2>/dev/null || echo "")"
+  if [[ "$cred_type" != "service_account" ]]; then
+    fail_open "credential type '${cred_type}' is not 'service_account' (WIF/external_account?) — skipping token mint."
+  fi
+
+  # Isolate gcloud state in a throwaway config dir so we never mutate the
+  # container's gcloud configuration (this runs as its own process, so the
+  # export cannot leak into terraform).
+  tmp_cfg="$(mktemp -d /tmp/gcp-preflight-cfg-XXXXXX 2>/dev/null || echo "")"
+  if [[ -z "$tmp_cfg" ]]; then
+    fail_open "could not create a temp gcloud config dir."
+  fi
+  trap 'rm -rf "$tmp_cfg"' EXIT
+  export CLOUDSDK_CONFIG="$tmp_cfg"
+
+  # A key gcloud cannot even load is a definitive bad-credential verdict.
+  if ! activate_out="$(gcloud auth activate-service-account --key-file="$CREDS_FILE" --quiet 2>&1)"; then
+    err ""
+    err "GCP BOOTSTRAP PREFLIGHT FAILED — could not load the service account key"
+    err "for ${sa_email}: the key is malformed, revoked, or invalid."
+    err "${activate_out}"
+    err "Ref: luthersystems/reliable#2243."
+    exit 1
+  fi
+
+  # Token exchange: distinguish an auth rejection (bad key -> fail closed) from
+  # a transient network/oauth error (fail open).
+  token_stderr="$(mktemp /tmp/gcp-preflight-err-XXXXXX 2>/dev/null || echo "")"
+  token="$(gcloud auth print-access-token --quiet 2>"${token_stderr:-/dev/null}")" || token=""
+  token_err=""
+  if [[ -n "$token_stderr" && -f "$token_stderr" ]]; then
+    token_err="$(cat "$token_stderr" 2>/dev/null || echo "")"
+    rm -f "$token_stderr"
+  fi
+
+  if [[ -z "$token" ]]; then
+    if grep -qiE 'invalid_grant|invalid_client|unauthorized_client|invalid_scope|PERMISSION_DENIED|UNAUTHENTICATED|\b401\b|\b403\b' <<<"$token_err"; then
+      err ""
+      err "GCP BOOTSTRAP PREFLIGHT FAILED — token exchange was REJECTED for"
+      err "${sa_email} (bad / revoked service account key):"
+      err "${token_err}"
+      err "Ref: luthersystems/reliable#2243."
+      exit 1
+    fi
+    fail_open "could not mint an access token (transient/network): ${token_err:-<no detail>}"
+  fi
+
+  url="https://cloudresourcemanager.googleapis.com/v1/projects/${PROJECT_ID}:testIamPermissions"
+  body="$(jq -cn '{permissions: $ARGS.positional}' --args "${REQUIRED_PERMISSIONS[@]}")"
+
+  # No `curl -f`: we WANT the HTTP body+code on a 4xx to reason about it. curl
+  # returns non-zero only on transport errors, which we treat as fail-open.
+  if ! curl_out="$(curl -sS -m 30 -X POST "$url" \
+    -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
+    -w $'\n%{http_code}' 2>/dev/null)"; then
+    fail_open "curl to testIamPermissions failed (network/transport error)."
+  fi
+
+  http_code="${curl_out##*$'\n'}"
+  response="${curl_out%$'\n'*}"
+fi
+
+# ----------------------------------------------------------------------------
+# Interpret the result. Only a clean 200 with a parseable body is a verdict.
+# ----------------------------------------------------------------------------
+if [[ "$http_code" != "200" ]]; then
+  fail_open "testIamPermissions returned HTTP ${http_code} (not a permission verdict; treating as infra/transient)."
+fi
+
+if ! jq -e . >/dev/null 2>&1 <<<"$response"; then
+  fail_open "testIamPermissions returned an unparseable 200 body (treating as infra/transient)."
+fi
+
+granted="$(jq -r '.permissions[]? // empty' <<<"$response" 2>/dev/null || echo "")"
+
+missing=()
+for perm in "${REQUIRED_PERMISSIONS[@]}"; do
+  if ! grep -qxF "$perm" <<<"$granted"; then
+    missing+=("$perm")
+  fi
+done
+
+if [[ ${#missing[@]} -eq 0 ]]; then
+  log "OK — service account ${sa_email} holds all ${#REQUIRED_PERMISSIONS[@]} bootstrap permissions on project ${PROJECT_ID}."
+  exit 0
+fi
+
+# --- fail closed: definitive missing-permission verdict ---
+err ""
+err "================================================================"
+err "GCP BOOTSTRAP PREFLIGHT FAILED — the provided service account"
+err "${sa_email} is missing ${#missing[@]} required permission(s) on project ${PROJECT_ID}:"
+for perm in "${missing[@]}"; do
+  err "  - ${perm}"
+done
+err ""
+err "Grant the service account roles/owner on the project (required anyway:"
+err "this bootstrap stage grants Owner to the InsideOut management service"
+err "account, which GCP only permits from a caller that itself holds Owner;"
+err "testIamPermissions cannot verify that, so passing this preflight does not"
+err "by itself guarantee the Owner grant will succeed)."
+err ""
+err "At minimum grant: roles/storage.admin + roles/iam.serviceAccountAdmin +"
+err "roles/resourcemanager.projectIamAdmin — then re-run the deploy."
+err ""
+err "Escape hatch: set SKIP_GCP_BOOTSTRAP_PREFLIGHT=1 to bypass this check."
+err "Ref: luthersystems/reliable#2243."
+err "================================================================"
+exit 1


### PR DESCRIPTION
Defense-in-depth half of luthersystems/reliable#2243 — the Beatloom incident: an under-privileged GCP SA reached the cloud-provision `terraform apply` and 403'd on `storage.buckets.create` / `iam.serviceAccounts.create` AFTER the GitHub half of the apply had already created resources (orphaned repo, deploy key, actions variables). Upstream preflights land in the companion PRs; this one protects every caller path and fails BEFORE terraform creates anything.

## Changes

- `tf/gcp-preflight.sh` (new): for the cloud-provision stage + GCP, calls `projects.testIamPermissions` (gcloud-minted token in an isolated `CLOUDSDK_CONFIG`, then curl to cloudresourcemanager) with the 10 bootstrap permissions before terraform runs. Missing permissions produce a prominent, greppable error block naming each one plus remediation (`roles/owner`, with the Owner-grant caveat, or the enumerated minimum roles) and exit 1.
- `tf/aws-preflight.sh` (new): AWS twin. Assumes `var.bootstrap_role` (with external id when configured) using ambient credentials, then `iam simulate-principal-policy` against the role for the 20 bootstrap actions, evaluated under the assumed-role session so the customer account's IAM answers. Ambient fallback maps assumed-role session ARNs back to role identity ARNs.
- Hooked into `setupCloudEnv()` (`shell_utils.sh`) — the single chokepoint both the mars-driven and direct-terraform apply paths flow through — gated on the `cloud-provision` stage directory and the matching cloud. All other stages untouched.
- Fail-closed only on a definitive verdict: a 200 testIamPermissions response with missing permissions, a bad-key token rejection, a non-allowed simulate decision, or assume-role AccessDenied (trust-policy/external-id problem, distinct message). Fail-open with a logged warning on anything transient (network, 5xx, throttling, missing CLI, simulate API errors) — the preflight can never brick a deploy on its own flakiness.
- `SKIP_GCP_BOOTSTRAP_PREFLIGHT=1` / `SKIP_AWS_BOOTSTRAP_PREFLIGHT=1` operator escape hatches.
- `tf/destroy.sh` exports both skip vars (review finding): the preflight must never block a teardown — a credential that was later locked down, or left orphaned partial state, must still be able to destroy its own stack. A regression test proves the skip is scoped to the destroy process and does not leak into apply paths.
- Permission/action lists mirror `reliable/internal/agentapi/bootstrap_permissions.go` with reciprocal citations; each test suite carries a golden-list drift guard.
- Tests wired into `.github/workflows/validate.yml`: `tests/test-gcp-preflight.sh` (14 assertions), `tests/test-aws-preflight.sh` (18), `tests/test-destroy-preflight-skip.sh` (7). All seam-driven — no live cloud calls, runs on CI runners without gcloud/aws.

## Testing

- `bash -n` + `shellcheck -x -S warning` (CI mirror) clean on all touched scripts.
- New suites 39/39; full existing script-test sweep re-run without regression (provider-selection 20, plan-all 56, tf-destroy-init 24, external-id 15, state-backend parity 4, entrypoint/reverse-import wrappers).
- Adversarial review pass completed; the destroy-path blocking bug was the one confirmed finding (fixed + regression-tested). Known low-harm gap left deliberately: `drift-refresh.sh` also trips the preflight against cloud-provision (drift-visibility only; same one-line skip applies if wanted).

## Companion PRs

- reliable: luthersystems/reliable#2244 — connect-time and dispatch-time preflights
- ui-core: luthersystems/ui-core#451 — Oracle single-project IAM preflight + Owner-grant check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR