### PR TITLE
Swap bootstrap preflight internals to the mars insideout-preflight binary (reliable#2243)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -144,3 +144,4 @@ jobs:
           bash tests/test-gcp-preflight.sh
           bash tests/test-aws-preflight.sh
           bash tests/test-destroy-preflight-skip.sh
+          bash tests/test-preflight-binary-swap.sh

--- a/tests/test-preflight-binary-swap.sh
+++ b/tests/test-preflight-binary-swap.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Wrapper-level tests for the mars#215 Go-binary swap in tf/gcp-preflight.sh and
+# tf/aws-preflight.sh (luthersystems/reliable#2243, final step of the chain).
+#
+# The scripts are now THIN three-tier wrappers:
+#   1. SKIP_*_BOOTSTRAP_PREFLIGHT=1  → skip.
+#   2. insideout-preflight on PATH   → delegate to the Go binary.
+#   3. binary absent / test seam set → legacy inline shell implementation.
+#
+# The pre-existing tests/test-{gcp,aws}-preflight.sh suites all set a
+# *_PREFLIGHT_TEST_* seam, so they exercise ONLY tier 3 (the legacy classifier) —
+# and, running on a CI runner where insideout-preflight is NOT installed, they
+# ALSO stand in for the "binary absent → legacy still enforces" fallback. This
+# file covers the parts those cannot reach:
+#   - tier 2 delegation: a fake `insideout-preflight` stub on PATH receives the
+#     right subcommand/args, and its exit code is mapped correctly (0→0, 1→1,
+#     and the exit-2 usage-error → fail-open(0) mapping);
+#   - tier-precedence: a set test seam beats a present binary (stub NOT called);
+#   - the SKIP var beats BOTH a present binary and a denied seam (stub NOT
+#     called, legacy classifier NOT run).
+#
+# Runs under `set -uo pipefail` (no -e) so a non-zero wrapper exit does not abort
+# the harness — every case captures $? explicitly. No aws/gcloud/live binary is
+# invoked (the stub or the seam short-circuits everything), so it runs on a bare
+# runner.
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GCP_PREFLIGHT="$SCRIPT_DIR/tf/gcp-preflight.sh"
+AWS_PREFLIGHT="$SCRIPT_DIR/tf/aws-preflight.sh"
+
+WORKDIR="$(mktemp -d /tmp/test-preflight-swap-XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# --- A fake insideout-preflight binary on PATH ----------------------------------
+# It records its FULL argv (one line) to $STUB_ARGS_LOG and exits with $STUB_EXIT
+# (default 0). Placed in $STUBDIR, which callers prepend to PATH.
+STUBDIR="$WORKDIR/bin"
+mkdir -p "$STUBDIR"
+STUB_ARGS_LOG="$WORKDIR/stub-args.log"
+cat > "$STUBDIR/insideout-preflight" <<'EOF'
+#!/usr/bin/env bash
+: > "${STUB_ARGS_LOG:?}"
+echo "$*" >> "$STUB_ARGS_LOG"
+exit "${STUB_EXIT:-0}"
+EOF
+chmod +x "$STUBDIR/insideout-preflight"
+
+# A dummy GCP creds file so --credentials-file is a non-empty, assertable value.
+DUMMY_CREDS="$WORKDIR/sa.json"
+echo '{"type":"service_account","client_email":"stub@example.iam.gserviceaccount.com"}' > "$DUMMY_CREDS"
+
+ROLE="arn:aws:iam::123456789012:role/insideout-bootstrap"
+
+# reset_stub — truncate the args log before each delegation case.
+reset_stub() { : > "$STUB_ARGS_LOG"; }
+stub_called() { [[ -s "$STUB_ARGS_LOG" ]]; }
+stub_argv()   { cat "$STUB_ARGS_LOG" 2>/dev/null || true; }
+
+# ============================================================================
+echo "=== GCP tier-2 delegation ==="
+# ============================================================================
+
+echo "Test G1: binary on PATH, no seam -> delegates with the right gcp args (exit 0 passthrough)"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" \
+  STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=0 \
+  GOOGLE_APPLICATION_CREDENTIALS="$DUMMY_CREDS" \
+  bash "$GCP_PREFLIGHT" test-project-123 2>&1)"
+rc=$?
+[[ "$rc" -eq 0 ]] && pass "exit 0 passthrough (binary passed)" || { fail "expected exit 0, got $rc"; echo "$OUT"; }
+argv="$(stub_argv)"
+if stub_called; then pass "the binary was invoked"; else fail "binary was NOT invoked (delegation did not happen)"; fi
+[[ "$argv" == gcp\ * ]] && pass "gcp subcommand first" || fail "argv should start with 'gcp': $argv"
+grep -q -- "--project-id test-project-123" <<<"$argv" && pass "--project-id forwarded" || fail "missing --project-id: $argv"
+grep -q -- "--credentials-file $DUMMY_CREDS" <<<"$argv" && pass "--credentials-file forwarded (GOOGLE_APPLICATION_CREDENTIALS)" || fail "missing --credentials-file: $argv"
+# REQUIRED_PERMISSIONS forwarded as a single comma-joined --permissions value,
+# including both #2243 create perms.
+if grep -qE -- "--permissions [^ ]*storage\.buckets\.create" <<<"$argv" \
+  && grep -q "iam.serviceAccounts.create" <<<"$argv" \
+  && grep -qE -- "--permissions [^ ]+,[^ ]+" <<<"$argv"; then
+  pass "--permissions is a comma-joined list carrying the #2243 create perms"
+else
+  fail "--permissions list malformed / missing create perms: $argv"
+fi
+
+echo ""
+echo "Test G2: binary returns 1 -> wrapper fails closed (exit 1 passthrough)"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=1 \
+  GOOGLE_APPLICATION_CREDENTIALS="$DUMMY_CREDS" \
+  bash "$GCP_PREFLIGHT" test-project-123 2>&1)"
+rc=$?
+[[ "$rc" -eq 1 ]] && pass "exit 1 passthrough (definitive fail-closed)" || { fail "expected exit 1, got $rc"; echo "$OUT"; }
+
+echo ""
+echo "Test G3: binary returns 2 (usage error) -> wrapper fails OPEN (exit 0 + warning)"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=2 \
+  GOOGLE_APPLICATION_CREDENTIALS="$DUMMY_CREDS" \
+  bash "$GCP_PREFLIGHT" test-project-123 2>&1)"
+rc=$?
+[[ "$rc" -eq 0 ]] && pass "exit 2 mapped to fail-open (exit 0)" || { fail "expected exit 0, got $rc"; echo "$OUT"; }
+if grep -qi "WARNING" <<<"$OUT" && grep -q "exited 2" <<<"$OUT"; then
+  pass "exit-2 mapping logs a loud warning naming the code"
+else
+  fail "exit-2 fail-open should warn and name the exit code: $OUT"
+fi
+
+echo ""
+echo "Test G4: test seam set -> legacy path wins even with the binary on PATH (stub NOT called)"
+# A denied 200 verdict via the seam: legacy classifier must fail closed, and the
+# binary must NOT be consulted (seam beats binary — tier precedence).
+resp_denied="$WORKDIR/gcp_denied.json"
+echo '{"permissions": ["storage.buckets.get"]}' > "$resp_denied"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=0 \
+  GCP_PREFLIGHT_TEST_RESPONSE_FILE="$resp_denied" GCP_PREFLIGHT_TEST_HTTP_CODE=200 \
+  GOOGLE_APPLICATION_CREDENTIALS="$DUMMY_CREDS" \
+  bash "$GCP_PREFLIGHT" test-project-123 2>&1)"
+rc=$?
+[[ "$rc" -eq 1 ]] && pass "seam-driven legacy verdict fails closed (exit 1)" || { fail "expected exit 1, got $rc"; echo "$OUT"; }
+if stub_called; then fail "binary was invoked despite the seam (seam must beat binary)"; else pass "binary NOT invoked (seam beat the binary)"; fi
+grep -q "GCP BOOTSTRAP PREFLIGHT FAILED" <<<"$OUT" && pass "legacy fail-closed marker surfaced" || fail "expected the legacy fail-closed marker: $OUT"
+
+echo ""
+echo "Test G5: binary absent + denied seam -> legacy fallback still enforces (exit 1)"
+# The binary-absent tier: no stub on PATH; the denied seam drives the legacy
+# classifier to a fail-closed verdict. (Mirrors tests/test-gcp-preflight.sh
+# Test 2 — the fallback path retains its teeth.)
+reset_stub
+OUT="$(GCP_PREFLIGHT_TEST_RESPONSE_FILE="$resp_denied" GCP_PREFLIGHT_TEST_HTTP_CODE=200 \
+  GOOGLE_APPLICATION_CREDENTIALS="$DUMMY_CREDS" \
+  bash "$GCP_PREFLIGHT" test-project-123 2>&1)"
+rc=$?
+[[ "$rc" -eq 1 ]] && pass "binary-absent legacy fallback fails closed (exit 1)" || { fail "expected exit 1, got $rc"; echo "$OUT"; }
+
+echo ""
+echo "Test G6: SKIP var beats BOTH a present binary and a denied seam (stub NOT called)"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=1 \
+  SKIP_GCP_BOOTSTRAP_PREFLIGHT=1 \
+  GCP_PREFLIGHT_TEST_RESPONSE_FILE="$resp_denied" GCP_PREFLIGHT_TEST_HTTP_CODE=200 \
+  GOOGLE_APPLICATION_CREDENTIALS="$DUMMY_CREDS" \
+  bash "$GCP_PREFLIGHT" test-project-123 2>&1)"
+rc=$?
+[[ "$rc" -eq 0 ]] && pass "skip wins (exit 0)" || { fail "expected exit 0, got $rc"; echo "$OUT"; }
+if stub_called; then fail "binary invoked despite SKIP=1"; else pass "binary NOT invoked (skip short-circuits before delegation)"; fi
+grep -q "skipping GCP bootstrap permission preflight" <<<"$OUT" && pass "skip notice logged" || fail "expected the skip notice: $OUT"
+
+# ============================================================================
+echo ""
+echo "=== AWS tier-2 delegation ==="
+# ============================================================================
+
+echo "Test A1: role mode, binary on PATH, no seam -> delegates with the right aws args (exit 0)"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=0 \
+  AWS_EXTERNAL_ID=ext-abc AWS_PREFLIGHT_REGION=us-west-2 \
+  bash "$AWS_PREFLIGHT" "$ROLE" 2>&1)"
+rc=$?
+[[ "$rc" -eq 0 ]] && pass "exit 0 passthrough (binary passed)" || { fail "expected exit 0, got $rc"; echo "$OUT"; }
+argv="$(stub_argv)"
+if stub_called; then pass "the binary was invoked"; else fail "binary was NOT invoked (delegation did not happen)"; fi
+[[ "$argv" == aws\ * ]] && pass "aws subcommand first" || fail "argv should start with 'aws': $argv"
+grep -q -- "--role-arn $ROLE" <<<"$argv" && pass "--role-arn forwarded" || fail "missing --role-arn: $argv"
+grep -q -- "--external-id ext-abc" <<<"$argv" && pass "--external-id forwarded" || fail "missing --external-id: $argv"
+grep -q -- "--region us-west-2" <<<"$argv" && pass "--region forwarded (AWS_PREFLIGHT_REGION)" || fail "missing --region: $argv"
+if grep -qE -- "--actions [^ ]*s3:CreateBucket" <<<"$argv" \
+  && grep -q "iam:CreateRole" <<<"$argv" \
+  && grep -qE -- "--actions [^ ]+,[^ ]+" <<<"$argv"; then
+  pass "--actions is a comma-joined list carrying the #2243 create actions"
+else
+  fail "--actions list malformed / missing create actions: $argv"
+fi
+
+echo ""
+echo "Test A2: ambient mode (empty role) -> delegates WITHOUT --role-arn/--external-id"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=0 \
+  AWS_EXTERNAL_ID=ext-abc AWS_PREFLIGHT_REGION=us-east-1 \
+  bash "$AWS_PREFLIGHT" "" 2>&1)"
+rc=$?
+[[ "$rc" -eq 0 ]] && pass "exit 0 passthrough (ambient mode)" || { fail "expected exit 0, got $rc"; echo "$OUT"; }
+argv="$(stub_argv)"
+[[ "$argv" == aws\ * ]] && pass "aws subcommand first" || fail "argv should start with 'aws': $argv"
+if grep -q -- "--role-arn" <<<"$argv"; then fail "ambient mode must NOT pass --role-arn: $argv"; else pass "no --role-arn in ambient mode"; fi
+if grep -q -- "--external-id" <<<"$argv"; then fail "ambient mode must NOT pass --external-id: $argv"; else pass "no --external-id in ambient mode (only meaningful with a role)"; fi
+grep -q -- "--region us-east-1" <<<"$argv" && pass "--region forwarded in ambient mode" || fail "missing --region: $argv"
+
+echo ""
+echo "Test A3: binary returns 1 -> wrapper fails closed (exit 1 passthrough)"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=1 \
+  bash "$AWS_PREFLIGHT" "$ROLE" 2>&1)"
+rc=$?
+[[ "$rc" -eq 1 ]] && pass "exit 1 passthrough (definitive fail-closed)" || { fail "expected exit 1, got $rc"; echo "$OUT"; }
+
+echo ""
+echo "Test A4: binary returns 2 (usage error) -> wrapper fails OPEN (exit 0 + warning)"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=2 \
+  bash "$AWS_PREFLIGHT" "$ROLE" 2>&1)"
+rc=$?
+[[ "$rc" -eq 0 ]] && pass "exit 2 mapped to fail-open (exit 0)" || { fail "expected exit 0, got $rc"; echo "$OUT"; }
+if grep -qi "WARNING" <<<"$OUT" && grep -q "exited 2" <<<"$OUT"; then
+  pass "exit-2 mapping logs a loud warning naming the code"
+else
+  fail "exit-2 fail-open should warn and name the exit code: $OUT"
+fi
+
+echo ""
+echo "Test A5: test seam set -> legacy path wins even with the binary on PATH (stub NOT called)"
+aws_denied="$WORKDIR/aws_denied.json"
+echo '{"EvaluationResults":[{"EvalActionName":"s3:CreateBucket","EvalDecision":"implicitDeny"}]}' > "$aws_denied"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=0 \
+  AWS_PREFLIGHT_TEST_SIMULATE_FILE="$aws_denied" \
+  bash "$AWS_PREFLIGHT" "$ROLE" 2>&1)"
+rc=$?
+[[ "$rc" -eq 1 ]] && pass "seam-driven legacy verdict fails closed (exit 1)" || { fail "expected exit 1, got $rc"; echo "$OUT"; }
+if stub_called; then fail "binary was invoked despite the seam (seam must beat binary)"; else pass "binary NOT invoked (seam beat the binary)"; fi
+grep -q "AWS BOOTSTRAP PREFLIGHT FAILED" <<<"$OUT" && pass "legacy fail-closed marker surfaced" || fail "expected the legacy fail-closed marker: $OUT"
+
+echo ""
+echo "Test A6: binary absent + denied seam -> legacy fallback still enforces (exit 1)"
+reset_stub
+OUT="$(AWS_PREFLIGHT_TEST_SIMULATE_FILE="$aws_denied" \
+  bash "$AWS_PREFLIGHT" "$ROLE" 2>&1)"
+rc=$?
+[[ "$rc" -eq 1 ]] && pass "binary-absent legacy fallback fails closed (exit 1)" || { fail "expected exit 1, got $rc"; echo "$OUT"; }
+
+echo ""
+echo "Test A7: SKIP var beats BOTH a present binary and a denied seam (stub NOT called)"
+reset_stub
+OUT="$(PATH="$STUBDIR:$PATH" STUB_ARGS_LOG="$STUB_ARGS_LOG" STUB_EXIT=1 \
+  SKIP_AWS_BOOTSTRAP_PREFLIGHT=1 \
+  AWS_PREFLIGHT_TEST_SIMULATE_FILE="$aws_denied" \
+  bash "$AWS_PREFLIGHT" "$ROLE" 2>&1)"
+rc=$?
+[[ "$rc" -eq 0 ]] && pass "skip wins (exit 0)" || { fail "expected exit 0, got $rc"; echo "$OUT"; }
+if stub_called; then fail "binary invoked despite SKIP=1"; else pass "binary NOT invoked (skip short-circuits before delegation)"; fi
+grep -q "skipping AWS bootstrap permission preflight" <<<"$OUT" && pass "skip notice logged" || fail "expected the skip notice: $OUT"
+
+echo ""
+echo "================================"
+echo "  $PASS passed, $FAIL failed"
+echo "================================"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tf/aws-preflight.sh
+++ b/tf/aws-preflight.sh
@@ -85,6 +85,28 @@
 # into locals and passed into the simulate call's OWN environment only, never
 # logged.
 #
+# Implementation — THREE-TIER DISPATCH (mars#215 Go swap, released mars v0.130.0,
+# ui-core#452 bumped marsVersion so the binary ships in every current deploy job
+# at /usr/local/bin/insideout-preflight). Twin of the block in gcp-preflight.sh:
+#   1. SKIP_AWS_BOOTSTRAP_PREFLIGHT=1  → skip (operator override; handled below).
+#   2. insideout-preflight on PATH     → DELEGATE to that Go binary. It reproduces
+#      this script's semantics + log markers byte-for-byte; the REQUIRED_ACTIONS
+#      list stays declared HERE (source of truth — it changes atomically with
+#      tf/cloud-provision/aws-resources.tf.tmpl) and is passed in as --actions.
+#      role/external-id/region are the same inputs the inline path resolves; an
+#      empty BOOTSTRAP_ROLE ⇒ omit --role-arn ⇒ the binary's ambient-caller mode.
+#   3. binary ABSENT (older pinned mars image) → fall through to the legacy inline
+#      aws-cli implementation below, UNCHANGED. Kept for one epoch; deleting it is
+#      a #2243 follow-up once no pinned mars < v0.130.0 remains anywhere.
+# This wrapper's external interface is preserved exactly across all three tiers.
+#
+# Test-seam carve-out: whenever TEST_MODE=1 (AWS_PREFLIGHT_TEST_SIMULATE_FILE /
+# AWS_PREFLIGHT_TEST_ASSUME_* set) we ALWAYS take the legacy inline path, never
+# the binary. Those seams inject canned simulate/assume-role outputs that only
+# the inline classifier can consume — the binary makes its own real SDK calls. So
+# the unit seams keep exercising the shell classifier; the binary delegation is
+# covered by the binary's own Go tests + tests/test-preflight-binary-swap.sh.
+#
 # Usage: bash aws-preflight.sh [<bootstrap_role_arn>]
 #   bootstrap role arn resolves from: $1 -> $AWS_BOOTSTRAP_ROLE (empty ⇒
 #     ambient-caller mode)
@@ -199,6 +221,42 @@ classify_assume_failure() {
   fi
   fail_open "could not assume bootstrap role ${BOOTSTRAP_ROLE} (transient — throttling/5xx/network/expired creds): ${errtext:-<no detail>}"
 }
+
+# ----------------------------------------------------------------------------
+# Tier 2 — delegate to the insideout-preflight Go binary when it is on PATH and
+# no test seam is active (see the THREE-TIER DISPATCH note in the header). The
+# binary owns the "checking…"/OK/fail-closed markers from here on. REQUIRED_ACTIONS
+# is the source of truth and is passed straight through as --actions; the role /
+# external-id / region are the same inputs the inline path resolves. An empty
+# BOOTSTRAP_ROLE omits --role-arn, selecting the binary's ambient-caller mode.
+# ----------------------------------------------------------------------------
+if [[ "$TEST_MODE" -eq 0 ]] && command -v insideout-preflight >/dev/null 2>&1; then
+  log "delegating to insideout-preflight (mars#215) — Go bootstrap-permission preflight"
+  actions_csv="$(IFS=','; echo "${REQUIRED_ACTIONS[*]}")"
+  bin_args=(aws --actions "$actions_csv" --region "$PREFLIGHT_REGION")
+  if [[ -n "$BOOTSTRAP_ROLE" ]]; then
+    bin_args+=(--role-arn "$BOOTSTRAP_ROLE")
+    if [[ -n "$EXTERNAL_ID" ]]; then
+      bin_args+=(--external-id "$EXTERNAL_ID")
+    fi
+  fi
+  insideout-preflight "${bin_args[@]}"
+  rc=$?
+  case "$rc" in
+    0) exit 0 ;; # pass, or the binary's own fail-open — non-fatal
+    1) exit 1 ;; # definitive fail-closed — the only blocking verdict
+    *)
+      # exit 2 (usage error) or any unexpected code is OUR bug (a bad arg/flag we
+      # passed), not a permission verdict. Only a definitive verdict may block a
+      # deploy, so fail OPEN loudly rather than abort the deploy on a wrapper bug.
+      fail_open "insideout-preflight exited ${rc} (usage/unexpected — a wrapper-argument bug, not a permission verdict)."
+      ;;
+  esac
+fi
+
+# --- Tier 3 (fallthrough): legacy inline aws-cli implementation ---
+# Reached only when the binary is absent OR an AWS_PREFLIGHT_TEST_* seam set
+# TEST_MODE=1. Unchanged from the pre-swap script.
 
 # ----------------------------------------------------------------------------
 # Phase 1 — resolve the policy-source ARN to simulate, assuming the bootstrap

--- a/tf/gcp-preflight.sh
+++ b/tf/gcp-preflight.sh
@@ -48,6 +48,28 @@
 # inline, and an unexpected `set -e` abort would surface as a non-zero exit —
 # which setupCloudEnv treats as fatal — i.e. the exact opposite of fail-open.
 #
+# Implementation — THREE-TIER DISPATCH (mars#215 Go swap, released mars v0.130.0,
+# ui-core#452 bumped marsVersion so the binary ships in every current deploy
+# job at /usr/local/bin/insideout-preflight):
+#   1. SKIP_GCP_BOOTSTRAP_PREFLIGHT=1  → skip (operator override; handled below).
+#   2. insideout-preflight on PATH     → DELEGATE to that Go binary. It reproduces
+#      this script's semantics + log markers byte-for-byte; the REQUIRED_PERMISSIONS
+#      list stays declared HERE (source of truth — it changes atomically with
+#      tf/cloud-provision/gcp-resources.tf.tmpl) and is passed in as --permissions.
+#   3. binary ABSENT (older pinned mars image) → fall through to the legacy inline
+#      gcloud+curl implementation below, UNCHANGED. Kept for one epoch; deleting it
+#      is a #2243 follow-up once no pinned mars < v0.130.0 remains anywhere.
+# This wrapper's external interface is preserved exactly across all three tiers:
+# invoked path, args/env consumed, SKIP var, exit semantics, greppable markers.
+#
+# Test-seam carve-out: whenever a GCP_PREFLIGHT_TEST_* seam is set we ALWAYS take
+# the legacy inline path, never the binary. The seams inject a canned raw
+# testIamPermissions HTTP body (GCP_PREFLIGHT_TEST_RESPONSE_FILE +
+# GCP_PREFLIGHT_TEST_HTTP_CODE) that only the inline comparison logic can consume
+# — the binary makes its own real API call and cannot ingest a fake body. So the
+# unit seams keep exercising the shell classifier; the binary delegation is
+# covered by the binary's own Go tests + tests/test-preflight-binary-swap.sh.
+#
 # Usage: bash gcp-preflight.sh [<gcp_project_id>]
 #   project id resolves from: $1 -> $GOOGLE_PROJECT -> $GCP_PROJECT_ID
 #   service-account key path: $GOOGLE_APPLICATION_CREDENTIALS
@@ -100,6 +122,38 @@ CREDS_FILE="${GOOGLE_APPLICATION_CREDENTIALS:-}"
 if [[ -z "$PROJECT_ID" ]]; then
   fail_open "no GCP project id (arg / GOOGLE_PROJECT / GCP_PROJECT_ID all empty)."
 fi
+
+# ----------------------------------------------------------------------------
+# Tier 2 — delegate to the insideout-preflight Go binary when it is on PATH and
+# no test seam is active (see the THREE-TIER DISPATCH note in the header). The
+# binary owns the "checking…"/OK/fail-closed markers from here on, so we do NOT
+# print the shell's own sa_email/"checking…" lines on this path (that would
+# duplicate the binary's byte-identical output). REQUIRED_PERMISSIONS is the
+# source of truth and is passed straight through as --permissions.
+# ----------------------------------------------------------------------------
+if [[ -z "${GCP_PREFLIGHT_TEST_RESPONSE_FILE:-}" ]] && command -v insideout-preflight >/dev/null 2>&1; then
+  log "delegating to insideout-preflight (mars#215) — Go bootstrap-permission preflight"
+  perms_csv="$(IFS=','; echo "${REQUIRED_PERMISSIONS[*]}")"
+  insideout-preflight gcp \
+    --project-id "$PROJECT_ID" \
+    --credentials-file "$CREDS_FILE" \
+    --permissions "$perms_csv"
+  rc=$?
+  case "$rc" in
+    0) exit 0 ;; # pass, or the binary's own fail-open — non-fatal
+    1) exit 1 ;; # definitive fail-closed — the only blocking verdict
+    *)
+      # exit 2 (usage error) or any unexpected code is OUR bug (a bad arg/flag we
+      # passed), not a permission verdict. Only a definitive verdict may block a
+      # deploy, so fail OPEN loudly rather than abort the deploy on a wrapper bug.
+      fail_open "insideout-preflight exited ${rc} (usage/unexpected — a wrapper-argument bug, not a permission verdict)."
+      ;;
+  esac
+fi
+
+# --- Tier 3 (fallthrough): legacy inline gcloud+curl implementation ---
+# Reached only when the binary is absent OR a GCP_PREFLIGHT_TEST_* seam forced
+# the legacy path. Unchanged from the pre-swap script.
 
 # Service-account email — best-effort, only used to make the message actionable.
 sa_email="unknown"


### PR DESCRIPTION
Final step of the luthersystems/reliable#2243 chain. Swaps the shell bootstrap-permission preflights to invoke the `insideout-preflight` Go binary now shipped in the mars image (mars#215, released mars v0.130.0; ui-core#452 bumped `marsVersion`, so the binary is at `/usr/local/bin/insideout-preflight` in every current deploy job).

## What changed

- `tf/gcp-preflight.sh` and `tf/aws-preflight.sh` become THIN wrappers that preserve their exact external interface: invoked path, args/env consumed, `SKIP_*_BOOTSTRAP_PREFLIGHT` vars, exit semantics, and greppable `[gcp-preflight]` / `[aws-preflight]` markers.
- `REQUIRED_PERMISSIONS` (10 GCP perms) and `REQUIRED_ACTIONS` (20 AWS actions) stay declared in these scripts — they remain the source of truth, changing atomically with the `cloud-provision` `.tf`, and are passed to the binary as `--permissions` / `--actions`.
- Adds `tests/test-preflight-binary-swap.sh` and wires it into `validate.yml`.

## Three-tier dispatch

Each wrapper now dispatches in order:

1. `SKIP_{AWS,GCP}_BOOTSTRAP_PREFLIGHT=1` → skip (unchanged, stays in the wrapper; checked before anything else).
2. `insideout-preflight` on PATH → delegate to the Go binary with the source-of-truth list plus the same inputs the shell path used (GCP: `GOOGLE_APPLICATION_CREDENTIALS` + project id; AWS: `bootstrap_role` / `aws_external_id` / region; empty `bootstrap_role` omits `--role-arn` → the binary's ambient-caller mode). Exit mapping: pass the binary's `0`/`1` through; treat exit `2` (usage error — a wrapper-argument bug) as fail-open with a loud warning, since only a definitive permission verdict may block a deploy.
3. Binary absent (older pinned mars image) → fall through to the CURRENT inline shell implementation, unchanged.

The binary reproduces the shell semantics and markers byte-for-byte, so the delegation path prints the binary's own `checking…`/OK/fail-closed lines (the wrapper does not duplicate them).

## Why the legacy inline path stays one epoch

It is kept as the tier-3 fallback so a deploy job running an older pinned mars image (one that predates v0.130.0 and therefore has no `insideout-preflight` binary) still gets a working preflight. Deleting the inline gcloud+curl / aws-cli implementation is a #2243 follow-up, once no pinned mars `< v0.130.0` remains anywhere.

## Test-seam carve-out

When a `*_PREFLIGHT_TEST_*` seam var is set, the wrapper always takes the legacy inline path — the seams inject canned raw API responses (`testIamPermissions` body / `simulate` + `assume-role` output) that only the inline classifier can consume; the binary makes its own real cloud calls. So the existing unit suites keep exercising the shell classifier. Documented at both dispatch sites.

## Tests

`bash -n` + `shellcheck -x -S warning` clean across the repo. All suites pass:

- `test-gcp-preflight.sh` — 14 passed (existing, unchanged)
- `test-aws-preflight.sh` — 18 passed (existing, unchanged)
- `test-destroy-preflight-skip.sh` — 7 passed (existing, unchanged)
- `test-preflight-binary-swap.sh` — 38 passed (new): binary-present delegation asserts the forwarded subcommand/args and exit-code passthrough (incl. the exit-2 → fail-open mapping and AWS role vs ambient mode); seam-beats-binary precedence; binary-absent legacy enforcement; and SKIP-beats-both.
- `test-provider-selection.sh` — 20 passed
- `test-plan-all.sh` — 56 passed

The `REQUIRED_PERMISSIONS` / `REQUIRED_ACTIONS` lists still match reliable `internal/agentapi/bootstrap_permissions.go` (10 GCP perms, 20 AWS actions).

## Rollout

Stage already runs mars v0.130.0, so the binary path (tier 2) is live-exercised on merge — the very first cloud-provision preflight after this lands will delegate to `insideout-preflight`, with the inline shell path retained only for older-mars fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR)_