### PR TITLE
fix(tf): cloud-provision AWS provider region tracks the project's actual region (#75)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -140,6 +140,7 @@ jobs:
           bash tests/test-reverse-import-wrapper.sh
           bash tests/test-external-id.sh
           bash tests/test-state-backend-output-parity.sh
+          bash tests/test-state-region.sh
           bash tests/test-plan-all.sh
           bash tests/test-gcp-preflight.sh
           bash tests/test-aws-preflight.sh

--- a/tests/test-state-region.sh
+++ b/tests/test-state-region.sh
@@ -1,13 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Validates that downstream remote-state data sources read their region from
-# cloud-provision outputs (not bare var.aws_region), so Terraform connects to
-# the correct S3 state bucket regardless of the project's resource region.
+# Guards the AWS *provider* region invariant across every provisioning stage,
+# and the downstream remote-state region invariant.
 #
-# Note: the AWS *provider* region in cloud-provision/providers.tf must use
-# var.aws_region — that is the project's resource region, NOT the state bucket
-# region. Only backend/remote-state configs need bootstrap_state_region.
+# INVARIANT (Check 1): an AWS `provider "aws"` block's `region =` must resolve
+# to the project's own resource region (var.aws_region) or a hard-coded region
+# literal (e.g. "us-east-1" for CloudFront/WAF, "us-west-2" for the GCP-path
+# fallback). It must NEVER be var.bootstrap_state_region.
+#
+# WHY — do NOT "fix" a region mismatch by switching the provider to
+# bootstrap_state_region. That exact change was made in PR #77 and reverted in
+# PR #79; issue #75 proposes it again (option 2). It is unsound:
+#   * aws_region is PER-PROJECT. ui-core sends it from cloudArgs.AWSRegion —
+#     the region the customer's resources (EKS, KMS, Route53, and the
+#     per-project state bucket module.bootstrap creates) actually live in.
+#   * bootstrap_state_region is a PLATFORM CONSTANT. ui-core sends it from
+#     s.config.BootstrapStateRegion — the region of the shared *environment
+#     bootstrap* state bucket. It is identical for every project the platform
+#     deploys (see ui-core jobs/workflows/workflows.go).
+#   These two agree only when a project happens to be deployed in the platform's
+#   bootstrap region; they DIVERGE for any cross-region project. Pointing the
+#   provider at bootstrap_state_region would create/read the customer's
+#   resources in the platform's region instead of the customer's — a much
+#   broader breakage than the corrupted-aws_region case #75 describes (which is
+#   repaired at the data source by ui-core's --force-region, PR #264).
+#
+# Only backend / remote-state *state-access* configs use bootstrap_state_region
+# (the separate, correct fix from PR #73), because the platform bootstrap state
+# bucket genuinely lives in the platform region. Check 2 covers the one
+# remote-state read that instead targets a PER-PROJECT bucket (vm-provision's
+# state), which must take its region from the cloud-provision output.
+#
+# History note: this guard originally hard-coded cloud-provision/providers.tf,
+# but the AWS provider block moved to providers-aws.tf.tmpl in PR #92. The old
+# guard then greped a file that no longer holds a provider region and silently
+# passed. Check 1 now scans every provider-declaration file and asserts the
+# known hot-spot file exists, so a future rename fails loudly instead of
+# dropping the guard.
 
 PASS=0
 FAIL=0
@@ -18,35 +48,64 @@ fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TF_DIR="$SCRIPT_DIR/tf"
 
-# --- Check 1: cloud-provision provider must use var.aws_region ---
-echo "Checking cloud-provision/providers.tf provider regions..."
+# --- Check 1: AWS provider region must not use bootstrap_state_region ---
+echo "Check 1: AWS provider region must not use bootstrap_state_region..."
 
-PROVIDERS_FILE="$TF_DIR/cloud-provision/providers.tf"
+c1_fail=0
 
-if [[ ! -f "$PROVIDERS_FILE" ]]; then
-  fail "cloud-provision/providers.tf not found"
-else
-  # The provider region must use var.aws_region (the project resource region).
-  # Using bootstrap_state_region here is incorrect — that is the state bucket
-  # region, not where resources should be created.
-  bad_lines="$(grep -n 'region\s*=' "$PROVIDERS_FILE" \
-    | grep 'bootstrap_state_region' || true)"
+# The cloud-provision AWS provider is the historical hot spot (issue #75). It
+# lives in a .tf.tmpl activated by _selectCloudFiles() at deploy time, so assert
+# it explicitly: a future rename must update this list, not silently drop the
+# guard.
+REQUIRED_PROVIDER_FILES=(
+  "cloud-provision/providers-aws.tf.tmpl"
+)
 
-  if [[ -z "$bad_lines" ]]; then
-    pass "cloud-provision/providers.tf: provider region uses var.aws_region (not bootstrap_state_region)"
-  else
-    fail "cloud-provision/providers.tf: provider region should use var.aws_region, not bootstrap_state_region:"
-    echo "$bad_lines" | sed 's/^/         /'
+for rel in "${REQUIRED_PROVIDER_FILES[@]}"; do
+  if [[ ! -f "$TF_DIR/$rel" ]]; then
+    fail "required provider file missing: tf/$rel (renamed? update this guard)"
+    c1_fail=1
   fi
+done
+
+# Scan every provider-declaration file in every stage (.tf and .tf.tmpl).
+shopt -s nullglob
+provider_files=("$TF_DIR"/*/providers*.tf "$TF_DIR"/*/providers*.tf.tmpl)
+shopt -u nullglob
+
+if [[ ${#provider_files[@]} -eq 0 ]]; then
+  fail "no provider files found under tf/*/ (glob may be wrong)"
+  c1_fail=1
+fi
+
+for pf in "${provider_files[@]}"; do
+  # A provider-block 'region =' line that references bootstrap_state_region is
+  # the bug pattern.
+  bad_lines="$(grep -nE 'region[[:space:]]*=' "$pf" \
+    | grep 'bootstrap_state_region' || true)"
+  if [[ -n "$bad_lines" ]]; then
+    fail "${pf#"$TF_DIR"/}: provider region uses bootstrap_state_region (must be var.aws_region or a region literal):"
+    echo "$bad_lines" | sed 's/^/         /'
+    c1_fail=1
+  fi
+done
+
+if [[ $c1_fail -eq 0 ]]; then
+  pass "all ${#provider_files[@]} provider files: region uses var.aws_region / region literal (never bootstrap_state_region)"
 fi
 
 # --- Check 2: Downstream remote-state data sources ---
 echo ""
-echo "Checking downstream remote-state region references..."
+echo "Check 2: per-project remote-state region references..."
 
-# These files contain terraform_remote_state blocks that access S3 state
-# created by cloud-provision. Their region should come from the
-# cloud-provision output, not var.aws_region.
+# These files contain terraform_remote_state blocks that read state created by
+# an EARLIER stage into a PER-PROJECT bucket (which lives in var.aws_region, not
+# the platform bootstrap region). Their region must come from the upstream
+# stage's output, not bare var.aws_region.
+#
+# NOTE: the *cloud-provision-state.tf files (which read cloud-provision's OWN
+# state from the platform bootstrap bucket) correctly use
+# var.bootstrap_state_region and are intentionally NOT listed here.
 STATE_FILES=(
   "k8s-provision/vm-provision-state.tf"
 )
@@ -59,13 +118,13 @@ for rel_path in "${STATE_FILES[@]}"; do
     continue
   fi
 
-  bad_lines="$(grep -n 'region\s*=' "$state_file" \
+  bad_lines="$(grep -nE 'region[[:space:]]*=' "$state_file" \
     | grep 'var\.aws_region' || true)"
 
   if [[ -z "$bad_lines" ]]; then
-    pass "$rel_path: region references cloud-provision output (not bare var.aws_region)"
+    pass "$rel_path: region references upstream stage output (not bare var.aws_region)"
   else
-    fail "$rel_path: uses var.aws_region for state region (should use cloud-provision output):"
+    fail "$rel_path: uses var.aws_region for state region (should use upstream stage output):"
     echo "$bad_lines" | sed 's/^/         /'
   fi
 done


### PR DESCRIPTION
Closes #75.

## TL;DR

Issue #75 proposes switching the cloud-provision AWS **provider** region from `var.aws_region` to `bootstrap_state_region` (option 2). Validating the premise shows option 2 is **unsound** — and it was in fact already tried (PR #77) and deliberately reverted (PR #79). The provider correctly stays on `var.aws_region` (the project's actual region). This PR instead repairs the regression guard that is supposed to enforce that invariant but had silently rotted, and wires it into CI.

**No `.tf` files change.** Two files: `tests/test-state-region.sh` (hardened + documented) and `.github/workflows/validate.yml` (guard added to CI).

## Premise validation — why option 2 is unsound

The issue's option 2 is explicitly conditioned on "if `bootstrap_state_region` always matches the project's resource region." It does not. The two tfvars have different scopes in the ui-core data flow (`jobs/workflows/workflows.go`):

- `aws_region` is **per-project** — sent from `cloudArgs.AWSRegion` / `args.AWSRegion` (the region the customer's resources actually live in: EKS, KMS, Route53, and the per-project state bucket `module.bootstrap` creates with `create_state_bucket = true`).
- `bootstrap_state_region` is a **platform-service constant** — sent from `s.config.BootstrapStateRegion`, the region of the shared *environment bootstrap* state bucket. It is identical for every project the platform deploys.

They coincide only when a project happens to be deployed in the platform's bootstrap region; they **diverge for any cross-region project** (a first-class, supported flow — `EffectiveAWSRegion`, `DefaultAWSRegion`, `ValidateAWSRegion`, and `--force-region` all exist). Pointing the provider at `bootstrap_state_region` would create/read the customer's resources in the *platform's* region instead of the customer's — a much broader breakage than the corrupted-`aws_region` case #75 describes, and it wouldn't even reliably fix that case (the platform region ≠ the corrupted project's original region in general).

This is exactly why PR #77 (which made option 2's change) was reverted by PR #79. Re-introducing it would revert the revert.

## Failure-mode explanation (the 301 in #75)

Once `aws_region` is corrupted (e.g. `us-east-1` → `us-west-2`) but the resources + per-project state bucket still physically live in `us-east-1`:
- The cloud-provision **backend** already uses `bootstrap_state_region` (PR #73), so its own state access is unaffected.
- The **provider** (region = `aws_region` = corrupted `us-west-2`) refreshes the `aws_s3_bucket` state-bucket *resource* that physically lives in `us-east-1` → S3 returns `301 MovedPermanently`.

The correct remedy is to repair the corrupted data at the source (ui-core `--force-region`, PR #264), not to conflate the provider region with the platform state-bucket region in the template — the template has no per-project source of truth for the true region other than `aws_region` itself.

## Architecture assumptions

- **`aws_region` is authoritative for where a project's singletons live.** It is the customer-chosen, per-project resource region; the provider must create/read resources there.
- **`bootstrap_state_region` is authoritative only for *state access*** to the shared platform bootstrap bucket. It is a platform constant, not a per-project resource region.
- **Single-region-per-project model.** A project's resources and its per-project state buckets are co-located in `aws_region` (see `aws-resources.tf.tmpl`: `state.region = var.aws_region`, and the bucket is created by the default `aws` provider).
- **A corrupted `aws_region` is recoverable data, not a re-deploy trigger.** It is fixed by correcting the stored value (ui-core `--force-region`), after which provider and resources realign — the template should not silently re-home resources to a different region to route around bad data.

## What changed and why

**`tests/test-state-region.sh` — hardened + self-documented.** The guard (added in PR #79) was meant to enforce "provider region uses `var.aws_region`, never `bootstrap_state_region`." But it grepped `cloud-provision/providers.tf`, and the AWS provider block moved to `providers-aws.tf.tmpl` in PR #92 — so Check 1 was greping a GitHub-provider-only file and trivially passing, giving zero protection. It now:
- scans **every** provider-declaration file across all six stages (`tf/*/providers*.tf` + `*.tf.tmpl`), covering the whole defect class rather than one file;
- asserts the known hot-spot file (`cloud-provision/providers-aws.tf.tmpl`) exists, so a future rename fails loudly instead of silently dropping the guard;
- documents the `aws_region`-vs-`bootstrap_state_region` scoping rationale (with the ui-core data-flow reason and the #75/#77/#79/#73/#264 references) inline, so the next reader doesn't re-attempt option 2.

Check 2 (downstream remote-state reads a per-project bucket → region from the upstream stage output) is preserved; its comment now clarifies that the `*cloud-provision-state.tf` files legitimately use `bootstrap_state_region` because they read the platform bootstrap bucket.

**`.github/workflows/validate.yml` — guard wired into CI.** `test-state-region.sh` was not in the `tests` job list, so the invariant had no enforcement at all. Added it.

## Stages touched / not touched

No stage's provider block changed — all six already correctly use `var.aws_region` (or a hard-coded `us-east-1` for CloudFront/WAF aliases and `us-west-2` for the GCP-path fallback):

| Stage | provider region | verdict |
|---|---|---|
| account-provision | `var.aws_region` | correct — unchanged |
| account-setup | `var.aws_region` | correct — unchanged |
| cloud-provision (`providers-aws.tf.tmpl`) | `var.aws_region` | correct — the #75 hot spot, guarded |
| vm-provision | `var.aws_region` (+ `us-east-1` alias) | correct — unchanged |
| k8s-provision | `var.aws_region` | correct — unchanged |
| custom-stack-provision (`providers-aws.tf.tmpl`) | `var.aws_region` (+ `us_east_1` alias) | correct — unchanged |

The GCP arm of each ternary (`var.gcp_region`) is likewise correct and is covered by the broadened scan.

## Test results

- `tests/test-state-region.sh`: **2 passed, 0 failed** on the current tree.
- Negative test: injecting option 2 (`bootstrap_state_region` ternary) into `cloud-provision/providers-aws.tf.tmpl` makes the guard **fail** (both provider blocks flagged, exit 1); reverting restores green. Proves the guard catches the class it exists for.
- `tests/test-provider-selection.sh`: 20 passed, 0 failed.
- `tests/test-state-backend-output-parity.sh`: 4 passed, 0 failed.
- `tests/test-plan-all.sh`: 56 passed, 0 failed.
- `bash -n` + `shellcheck -x -S warning tests/test-state-region.sh`: clean.
- `terraform fmt -check -recursive` (tf/): clean (no `.tf` touched).
- `validate.yml`: valid YAML.
- `terraform validate` on cloud-provision could not complete **in the sandbox only** — the proxy returns 403 for the `integrations/github` provider registry download (AWS/random/local/tls/time install fine). Unrelated to this change (no `.tf` touched); GitHub Actions runs it normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR)_