### PR TITLE
fix: populate -infra repos — loud git push path + carry repo_clone_ssh_url/.git to the apply tree (#143)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -135,6 +135,9 @@ jobs:
       - name: Run tests
         run: |
           bash tests/test-prepare-custom-stack.sh
+          bash tests/test-infra-push.sh
+          bash tests/test-apply-scripts.sh
+          bash tests/test-drift-check.sh
           bash tests/test-tf-destroy-init.sh
           bash tests/test-mars-entrypoint-compat.sh
           bash tests/test-reverse-import-wrapper.sh

--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -120,13 +120,25 @@ ensure_infra_remote() {
     else
       git remote add infra "$url"
     fi
-    echo "🔧 infra remote configured → $url"
+    echo "🔧 [git-infra] infra remote configured → $url"
+  else
+    # LOUD, greppable signal for hypothesis (1) in
+    # sandbox-infrastructure-template#143: cloud-provision writes
+    # tf/auto-vars/git_repo.auto.tfvars.json with repo_clone_ssh_url, but if
+    # that auto-var did not reach this working tree the infra remote is never
+    # wired and the per-project -infra repo stays empty. Non-fatal: may be
+    # benign on early stages (before cloud-provision) but is a real problem on
+    # custom-stack-provision.
+    echo "⚠️  [git-infra] WARNING: repo_clone_ssh_url is empty in ${AUTO_VARS_DIR} — 'infra' remote NOT configured; the per-project -infra repo will NOT be populated. [sandbox-infrastructure-template#143]" >&2
   fi
 }
 
 configure_git() {
   if ! has_git_repo; then
-    echo "⚠️  configure_git: no .git at $MARS_PROJECT_ROOT"
+    # LOUD, greppable signal for hypothesis (2) in #143: no .git at the project
+    # root means prepare-custom-stack's ensure_git_from_infra never ran (or its
+    # clone failed), so nothing can be committed or pushed to the -infra repo.
+    echo "⚠️  [git-infra] WARNING: configure_git: no .git at ${MARS_PROJECT_ROOT} — commit/push to the -infra repo will be SKIPPED. [sandbox-infrastructure-template#143]" >&2
     return 1
   fi
   pushd "$MARS_PROJECT_ROOT" >/dev/null
@@ -185,13 +197,67 @@ gitMergeOriginMain() {
 
 gitPushInfra() {
   pushd "$MARS_PROJECT_ROOT" >/dev/null
-  if git remote get-url infra >/dev/null 2>&1; then
-    echo "🚀 Pushing to infra…"
-    git push infra HEAD
-  else
-    echo "Skipping gitPushInfra: no infra remote configured"
+
+  if ! git remote get-url infra >/dev/null 2>&1; then
+    # Previously this returned 0 silently ("Skipping gitPushInfra: no infra
+    # remote configured"), which is exactly how #143 went unnoticed: a
+    # successful apply left the -infra repo empty and reported SUCCESS. Warn
+    # LOUDLY (greppable) instead. Still non-fatal — a push problem must never
+    # turn an already-successful deploy into a failure.
+    echo "⚠️  [git-infra] WARNING: no 'infra' remote configured — NOT pushing; the per-project -infra repo will stay EMPTY. [sandbox-infrastructure-template#143]" >&2
+    popd >/dev/null
+    return 0
   fi
+
+  # A freshly-cloned empty infra repo has no HEAD until gitCommit runs. If there
+  # is still nothing to push, say so loudly rather than pushing nothing.
+  if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+    echo "⚠️  [git-infra] WARNING: no HEAD/commit to push (nothing was committed) — the per-project -infra repo will stay EMPTY. [sandbox-infrastructure-template#143]" >&2
+    popd >/dev/null
+    return 0
+  fi
+
+  echo "🚀 [git-infra] Pushing HEAD to infra remote…"
+  if git push infra HEAD; then
+    echo "✅ [git-infra] Pushed to infra remote — per-project -infra repo populated."
+  else
+    echo "⚠️  [git-infra] WARNING: 'git push infra HEAD' FAILED — the per-project -infra repo may stay EMPTY. Deploy is NOT failed (apply already succeeded); investigate the deploy key / remote URL. [sandbox-infrastructure-template#143]" >&2
+  fi
+
   popd >/dev/null
+}
+
+# persistInfraRepo commits the applied working tree and pushes it to the
+# per-project -infra GitHub repo. It is the durable-persistence entry point for
+# the apply code paths that ACTUALLY run in production — apply-with-outputs.sh
+# (--check-drift) and apply-plan.sh — which, unlike apply.sh, never otherwise
+# reach gitPushInfra. That gap is the root cause of #143: ui-core always sets
+# checkDrift=true on custom-stack applies, so the git merge/commit/push in
+# apply.sh was dead code and 89/89 -infra repos were left empty.
+#
+# Contract: NON-FATAL and LOUD. A deploy that already applied must never be
+# turned into a failure by a git/push problem, and every skip/failure is logged
+# with a greppable "[git-infra] WARNING:" prefix so a silent no-op can never
+# regress unnoticed again. Always returns 0.
+persistInfraRepo() {
+  echo "📦 [git-infra] Persisting applied stack to the per-project -infra repo…"
+
+  # Up-front LOUD signals for the two silent-failure hypotheses in #143. These
+  # are pure diagnostics; the helper calls below also degrade gracefully.
+  if ! has_git_repo; then
+    echo "⚠️  [git-infra] WARNING: no .git at ${MARS_PROJECT_ROOT} at persist time — prepare-custom-stack's ensure_git_from_infra should have cloned the -infra repo. Stack will NOT be pushed. [sandbox-infrastructure-template#143]" >&2
+  fi
+  if [ -z "$(getTfVar repo_clone_ssh_url)" ]; then
+    echo "⚠️  [git-infra] WARNING: repo_clone_ssh_url is empty at persist time — cloud-provision's git_repo.auto.tfvars.json did not reach the apply working tree. [sandbox-infrastructure-template#143]" >&2
+  fi
+
+  # gitMergeInfraMain returns non-zero on a merge conflict; guard it so
+  # persistInfraRepo (called under `set -e`) never aborts the caller.
+  gitMergeInfraMain || echo "⚠️  [git-infra] WARNING: gitMergeInfraMain returned non-zero (continuing; non-fatal). [sandbox-infrastructure-template#143]" >&2
+  gitCommit "auto-commit: deployed infrastructure [ci skip]"
+  gitPushInfra
+
+  return 0
 }
 
 gitMergeInfraMain() {

--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -251,11 +251,17 @@ persistInfraRepo() {
     echo "⚠️  [git-infra] WARNING: repo_clone_ssh_url is empty at persist time — cloud-provision's git_repo.auto.tfvars.json did not reach the apply working tree. [sandbox-infrastructure-template#143]" >&2
   fi
 
-  # gitMergeInfraMain returns non-zero on a merge conflict; guard it so
-  # persistInfraRepo (called under `set -e`) never aborts the caller.
+  # Each helper is individually guarded with `|| echo` so persistInfraRepo
+  # honors its "Always returns 0" contract in EVERY caller context — not only
+  # when the call site adds its own `|| …` (which suspends `set -e` across the
+  # whole body). Without these guards a hard git failure (gitMergeInfraMain's
+  # merge-conflict `return 1`, or a gitCommit/gitPushInfra that aborts mid-body
+  # under an active `set -e`, e.g. a rejecting pre-commit hook) could brick an
+  # already-applied deploy if a future caller ever invoked persistInfraRepo bare.
+  # Belt-and-suspenders on the exact #143 brick path.
   gitMergeInfraMain || echo "⚠️  [git-infra] WARNING: gitMergeInfraMain returned non-zero (continuing; non-fatal). [sandbox-infrastructure-template#143]" >&2
-  gitCommit "auto-commit: deployed infrastructure [ci skip]"
-  gitPushInfra
+  gitCommit "auto-commit: deployed infrastructure [ci skip]" || echo "⚠️  [git-infra] WARNING: gitCommit returned non-zero (continuing; non-fatal). [sandbox-infrastructure-template#143]" >&2
+  gitPushInfra || echo "⚠️  [git-infra] WARNING: gitPushInfra returned non-zero (continuing; non-fatal). [sandbox-infrastructure-template#143]" >&2
 
   return 0
 }

--- a/tests/test-infra-push.sh
+++ b/tests/test-infra-push.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Seam test for the per-project -infra repo push path (issue #143).
+#
+# Root cause captured here: ui-core always runs a custom-stack apply through the
+# drift-check code path — `apply-with-outputs.sh <lc> --check-drift` or
+# `apply-plan.sh <lc> --plan-file <id> --check-drift`. Neither of those branches
+# used to reach gitMergeInfraMain/gitCommit/gitPushInfra (only apply.sh did, and
+# ui-core never invokes apply.sh for an apply), so 89/89 -infra repos were left
+# EMPTY despite a SUCCESS. The fix wires persistInfraRepo into both real apply
+# paths, scoped to the custom-stack-provision stage.
+#
+# This test uses a MOCK terraform (no cloud) but REAL git, driving the actual
+# apply-with-outputs.sh / apply-plan.sh scripts against a local bare "infra"
+# repo. It asserts:
+#   (i)  the push path is reached and a ref lands on the infra repo when the
+#        repo_clone_ssh_url auto-var + a .git are present (custom-stack stage);
+#   (ii) the loud, greppable "[git-infra] WARNING:" fires (and the apply still
+#        exits 0) when either the .git or the auto-var is absent;
+#   (iii) the persist step is SCOPED to custom-stack-provision — a non-custom
+#        apply stage does not push.
+#
+# No rsync dependency (unlike test-prepare-custom-stack.sh) so it runs anywhere
+# git + jq + a POSIX terraform mock are available.
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+WORKDIR="$(mktemp -d)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v jq &>/dev/null; then
+  echo "SKIP: jq is required for these tests" >&2
+  exit 0
+fi
+if ! command -v git &>/dev/null; then
+  echo "SKIP: git is required for these tests" >&2
+  exit 0
+fi
+
+# --- Mock binaries (terraform / mars / chmod) ---------------------------------
+MOCK_BIN="$WORKDIR/bin"
+mkdir -p "$MOCK_BIN"
+
+CMD_LOG="$WORKDIR/cmd-log.txt"
+TF_SHOW_OUTPUT="$WORKDIR/show-output.json"
+TF_OUTPUT_JSON="$WORKDIR/output-json.json"
+MOCK_MARS="$WORKDIR/mock-mars.sh"
+
+echo '{"resource_drift": []}' > "$TF_SHOW_OUTPUT"
+echo '{"vpc_id": {"value": "vpc-123"}}' > "$TF_OUTPUT_JSON"
+
+cat > "$MOCK_BIN/terraform" <<OUTER
+#!/usr/bin/env bash
+echo "terraform \$*" >> "$CMD_LOG"
+if [[ "\$1" == "show" && "\$2" == "-json" ]]; then
+  cat "$TF_SHOW_OUTPUT"
+elif [[ "\$1" == "output" && "\$2" == "-json" ]]; then
+  cat "$TF_OUTPUT_JSON"
+elif [[ "\$1" == "init" ]]; then
+  :
+elif [[ "\$1" == "plan" ]]; then
+  for arg in "\$@"; do
+    if [[ "\$arg" == -out=* ]]; then touch "\${arg#-out=}"; fi
+  done
+elif [[ "\$1" == "apply" ]]; then
+  :
+fi
+OUTER
+chmod +x "$MOCK_BIN/terraform"
+
+cat > "$MOCK_MARS" <<OUTER
+#!/usr/bin/env bash
+echo "mars \$*" >> "$CMD_LOG"
+OUTER
+chmod +x "$MOCK_MARS"
+
+# chmod is a no-op mock so utils.sh's chmod on the mars wrapper never fails.
+cat > "$MOCK_BIN/chmod" <<'OUTER'
+#!/usr/bin/env bash
+exit 0
+OUTER
+chmod +x "$MOCK_BIN/chmod"
+
+export PATH="$MOCK_BIN:$PATH"
+
+# --- Project-tree factory -----------------------------------------------------
+# make_project <name> — build a fake mars project tree with the real scripts.
+make_project() {
+  local proj="$WORKDIR/$1"
+  mkdir -p "$proj/tf/auto-vars"
+  mkdir -p "$proj/ansible/inventories/default/group_vars/all"
+  mkdir -p "$proj/outputs"
+  cat > "$proj/ansible/inventories/default/group_vars/all/env.yaml" <<'EOF'
+environment: test
+EOF
+  echo '{"cloud_provider": "aws"}' > "$proj/tf/auto-vars/common.auto.tfvars.json"
+  cp "$REPO_ROOT/shell_utils.sh" "$proj/shell_utils.sh"
+  cp "$REPO_ROOT/tf/utils.sh" "$proj/tf/utils.sh"
+  cp "$REPO_ROOT/tf/drift-check.sh" "$proj/tf/drift-check.sh"
+  cp "$REPO_ROOT/tf/apply-with-outputs.sh" "$proj/tf/apply-with-outputs.sh"
+  cp "$REPO_ROOT/tf/apply-plan.sh" "$proj/tf/apply-plan.sh"
+  # Mock apply.sh (only reached by simple mode, which these tests don't use).
+  printf '#!/usr/bin/env bash\necho "apply.sh $*" >> "%s"\n' "$CMD_LOG" > "$proj/tf/apply.sh"
+  chmod +x "$proj/tf/apply.sh"
+  echo "$proj"
+}
+
+# set_repo_clone_url <proj> <url> — add repo_clone_ssh_url to auto-vars.
+set_repo_clone_url() {
+  jq -n --arg url "$2" '{"cloud_provider":"aws","repo_clone_ssh_url":$url}' \
+    > "$1/tf/auto-vars/common.auto.tfvars.json"
+}
+
+# init_project_git <proj> — real git repo at project root (branch main).
+init_project_git() {
+  git -C "$1" init -q -b main
+  git -C "$1" config user.email "test@luthersystems.com"
+  git -C "$1" config user.name "Test"
+}
+
+# fresh_bare — a new empty bare repo to receive pushes; prints its path.
+fresh_bare() {
+  local bare="$WORKDIR/infra-$RANDOM-$RANDOM.git"
+  git init -q --bare "$bare"
+  echo "$bare"
+}
+
+# run_apply <proj> <script> <args...> — run an apply script in the project.
+run_apply() {
+  local proj="$1"; shift
+  local script="$1"; shift
+  : > "$CMD_LOG"
+  (
+    cd "$proj/tf"
+    export MARS_PROJECT_ROOT="$proj"
+    export MARS="$MOCK_MARS"
+    export HOME="$WORKDIR"
+    # No JUMP_ROLE_ARN; stage dir basename gates the preflight, not lifecycle.
+    bash "$proj/tf/$script" "$@"
+  ) 2>&1
+}
+
+bare_commit_count() { git -C "$1" rev-list --all --count 2>/dev/null || echo 0; }
+
+# =============================================================================
+echo "=== Case A: apply-with-outputs --check-drift populates -infra repo ==="
+# =============================================================================
+PROJ="$(make_project projA)"
+BARE="$(fresh_bare)"
+set_repo_clone_url "$PROJ" "file://$BARE"
+init_project_git "$PROJ"
+
+set +e
+outA="$(run_apply "$PROJ" apply-with-outputs.sh custom-stack-provision --check-drift)"
+rcA=$?
+set -e
+
+[[ "$rcA" -eq 0 ]] && pass "A: apply exits 0" || fail "A: expected exit 0, got $rcA. Output: $outA"
+
+if echo "$outA" | grep -qF "[git-infra] Persisting applied stack"; then
+  pass "A: persistInfraRepo was reached (custom-stack scope)"
+else
+  fail "A: persist step not reached. Output: $outA"
+fi
+
+if echo "$outA" | grep -qF "[git-infra] Pushed to infra remote"; then
+  pass "A: push success line printed"
+else
+  fail "A: expected push-success line. Output: $outA"
+fi
+
+if [[ "$(bare_commit_count "$BARE")" -ge 1 ]]; then
+  pass "A: a ref landed on the (previously empty) -infra repo"
+else
+  fail "A: -infra repo is still empty after a successful apply (#143 regression)"
+fi
+
+if git -C "$BARE" for-each-ref --format='%(refname)' | grep -qF 'refs/heads/main'; then
+  pass "A: ref landed on refs/heads/main"
+else
+  fail "A: no refs/heads/main on the infra repo. refs: $(git -C "$BARE" for-each-ref)"
+fi
+
+# =============================================================================
+echo ""
+echo "=== Case B: apply-plan --check-drift populates -infra repo ==="
+# =============================================================================
+PROJ="$(make_project projB)"
+BARE="$(fresh_bare)"
+set_repo_clone_url "$PROJ" "file://$BARE"
+init_project_git "$PROJ"
+# Pre-create the saved plan file where apply-plan.sh expects it.
+mkdir -p "$PROJ/tf/custom-stack-provision"
+echo "fake-plan" > "$PROJ/tf/custom-stack-provision/myplan.tfplan"
+
+set +e
+outB="$(run_apply "$PROJ" apply-plan.sh custom-stack-provision --plan-file myplan --check-drift)"
+rcB=$?
+set -e
+
+[[ "$rcB" -eq 0 ]] && pass "B: apply-plan exits 0" || fail "B: expected exit 0, got $rcB. Output: $outB"
+
+if echo "$outB" | grep -qF "[git-infra] Persisting applied stack"; then
+  pass "B: persistInfraRepo was reached"
+else
+  fail "B: persist step not reached. Output: $outB"
+fi
+
+if [[ "$(bare_commit_count "$BARE")" -ge 1 ]]; then
+  pass "B: a ref landed on the -infra repo via apply-plan.sh"
+else
+  fail "B: apply-plan.sh left the -infra repo empty (#143 regression)"
+fi
+
+# =============================================================================
+echo ""
+echo "=== Case C: no .git → LOUD warning, no push, apply still succeeds ==="
+# =============================================================================
+PROJ="$(make_project projC)"
+BARE="$(fresh_bare)"
+set_repo_clone_url "$PROJ" "file://$BARE"
+# NOTE: deliberately NOT initializing .git at the project root.
+
+set +e
+outC="$(run_apply "$PROJ" apply-with-outputs.sh custom-stack-provision --check-drift)"
+rcC=$?
+set -e
+
+[[ "$rcC" -eq 0 ]] && pass "C: apply exits 0 even without .git (non-fatal)" \
+  || fail "C: expected exit 0, got $rcC. Output: $outC"
+
+if echo "$outC" | grep -qF "[git-infra] WARNING:" && echo "$outC" | grep -qF "no .git"; then
+  pass "C: loud '[git-infra] WARNING: ... no .git' fired"
+else
+  fail "C: expected a loud no-.git warning. Output: $outC"
+fi
+
+if [[ "$(bare_commit_count "$BARE")" -eq 0 ]]; then
+  pass "C: nothing pushed when .git is absent"
+else
+  fail "C: something was pushed despite missing .git"
+fi
+
+# =============================================================================
+echo ""
+echo "=== Case D: repo_clone_ssh_url empty → LOUD warning, no remote, exits 0 ==="
+# =============================================================================
+PROJ="$(make_project projD)"
+init_project_git "$PROJ"
+# auto-vars intentionally has NO repo_clone_ssh_url (default from make_project).
+
+set +e
+outD="$(run_apply "$PROJ" apply-with-outputs.sh custom-stack-provision --check-drift)"
+rcD=$?
+set -e
+
+[[ "$rcD" -eq 0 ]] && pass "D: apply exits 0 even with empty repo_clone_ssh_url" \
+  || fail "D: expected exit 0, got $rcD. Output: $outD"
+
+if echo "$outD" | grep -qF "[git-infra] WARNING:" && echo "$outD" | grep -qF "repo_clone_ssh_url is empty"; then
+  pass "D: loud '[git-infra] WARNING: ... repo_clone_ssh_url is empty' fired"
+else
+  fail "D: expected a loud empty-URL warning. Output: $outD"
+fi
+
+if echo "$outD" | grep -qF "no 'infra' remote configured"; then
+  pass "D: gitPushInfra warned that no infra remote is configured"
+else
+  fail "D: expected 'no infra remote configured' warning. Output: $outD"
+fi
+
+# =============================================================================
+echo ""
+echo "=== Case E: persist is SCOPED to custom-stack-provision ==="
+# =============================================================================
+PROJ="$(make_project projE)"
+BARE="$(fresh_bare)"
+set_repo_clone_url "$PROJ" "file://$BARE"
+init_project_git "$PROJ"
+
+set +e
+outE="$(run_apply "$PROJ" apply-with-outputs.sh vm-provision --check-drift)"
+rcE=$?
+set -e
+
+[[ "$rcE" -eq 0 ]] && pass "E: non-custom apply exits 0" || fail "E: expected exit 0, got $rcE. Output: $outE"
+
+if echo "$outE" | grep -qF "[git-infra] Persisting applied stack"; then
+  fail "E: persist step ran for a NON custom-stack lifecycle (should be scoped out)"
+else
+  pass "E: persist step correctly skipped for vm-provision"
+fi
+
+if [[ "$(bare_commit_count "$BARE")" -eq 0 ]]; then
+  pass "E: nothing pushed for a non-custom-stack apply"
+else
+  fail "E: a non-custom apply pushed to the -infra repo"
+fi
+
+# =============================================================================
+echo ""
+echo "=== Case F: re-deploy — second apply fast-forwards the -infra repo ==="
+# =============================================================================
+PROJ="$(make_project projF)"
+BARE="$(fresh_bare)"
+set_repo_clone_url "$PROJ" "file://$BARE"
+init_project_git "$PROJ"
+
+set +e
+run_apply "$PROJ" apply-with-outputs.sh custom-stack-provision --check-drift >/dev/null
+first_rc=$?
+set -e
+first_count="$(bare_commit_count "$BARE")"
+
+# Mutate the working tree so the second apply has something new to commit.
+echo "second-deploy-change" > "$PROJ/tf/custom-stack-provision/main.tf"
+
+set +e
+outF="$(run_apply "$PROJ" apply-with-outputs.sh custom-stack-provision --check-drift)"
+rcF=$?
+set -e
+second_count="$(bare_commit_count "$BARE")"
+
+if [[ "$first_rc" -eq 0 && "$rcF" -eq 0 ]]; then
+  pass "F: both applies exit 0"
+else
+  fail "F: apply exit codes first=$first_rc second=$rcF. Output: $outF"
+fi
+
+if [[ "$first_count" -ge 1 && "$second_count" -gt "$first_count" ]]; then
+  pass "F: re-deploy added a new commit to the -infra repo ($first_count → $second_count)"
+else
+  fail "F: re-deploy did not advance the -infra repo ($first_count → $second_count)"
+fi
+
+# --- Summary -----------------------------------------------------------------
+echo ""
+echo "================================"
+echo "  $PASS passed, $FAIL failed"
+echo "================================"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tf/apply-plan.sh
+++ b/tf/apply-plan.sh
@@ -106,6 +106,19 @@ captureOutputs() {
 
 captureOutputs
 
+# Persist the applied stack to the per-project -infra repo (#143).
+#
+# The saved-plan apply path (ui-core makeApplyAllFromPlanWorkflow) runs this
+# script with checkDrift=true and, like the drift-check branch of
+# apply-with-outputs.sh, never reaches apply.sh's gitPushInfra. Scope to
+# custom-stack-provision (the stage carrying the full generated stack, with the
+# infra .git + remote wired by prepare-custom-stack in the prior plan
+# workflow). Non-fatal by contract.
+if [[ "$lifecycle" == "custom-stack-provision" ]]; then
+  persistInfraRepo || \
+    echo "⚠️  [git-infra] WARNING: persistInfraRepo returned non-zero (non-fatal; deploy already applied). [sandbox-infrastructure-template#143]" >&2
+fi
+
 # Write drift.json stub if drift-check didn't produce one (not invoked, or
 # invoked but no drift). Mirrors the full drift-check.sh schema so consumers
 # get the same shape regardless of whether drift occurred, including the

--- a/tf/apply-with-outputs.sh
+++ b/tf/apply-with-outputs.sh
@@ -85,6 +85,21 @@ if [[ "$check_drift" == "true" ]]; then
 
   terraform apply -input=false apply.tfplan
   captureOutputs
+
+  # Persist the applied stack to the per-project -infra repo (#143).
+  #
+  # This drift-check branch — NOT apply.sh — is what ui-core actually runs for a
+  # custom-stack apply (it always sets checkDrift=true), so without this call
+  # gitPushInfra is never reached and the -infra repo stays empty despite a
+  # SUCCESS. Scope to custom-stack-provision: that stage carries the full
+  # generated stack and has the infra .git + remote wired by
+  # prepare-custom-stack; earlier stages have no .git yet and would only emit
+  # spurious warnings. Non-fatal by contract — a push problem must not fail an
+  # already-applied deploy.
+  if [[ "$lifecycle" == "custom-stack-provision" ]]; then
+    persistInfraRepo || \
+      echo "⚠️  [git-infra] WARNING: persistInfraRepo returned non-zero (non-fatal; deploy already applied). [sandbox-infrastructure-template#143]" >&2
+  fi
 else
   # Simple mode: delegate to apply.sh (includes git merge/commit/push)
   bash "$SCRIPT_DIR/apply.sh" "$lifecycle"


### PR DESCRIPTION
## Summary

Fixes #143. Every deploy creates a per-project `<short>-infra` GitHub repo and invites the deploying user, but the repo is never populated — **89/89 `-infra` repos are empty despite 96 projects having a `JOB_STATUS_SUCCESS` apply.**

## Confirmed root-cause mechanism

Traced through ui-core `jobs/workflows/workflows.go`. The custom-stack apply that ui-core actually runs **never reaches the git push helpers** — not because of a missing auto-var or `.git` (the issue's three hypotheses), but because the push code path is dead code in the real deploy flow:

- `apply.sh` is the only script that calls `gitMergeInfraMain → gitCommit → gitPushInfra`.
- ui-core dispatches a custom-stack apply one of two ways, and **both** set `checkDrift=true`:
  - `makeCreateCustomStackWorkflow` injects `checkDrift=true` on every apply step (`workflows.go:2463-2465`) → runs `apply-with-outputs.sh custom-stack-provision --check-drift`.
  - `makeApplyAllFromPlanWorkflow` sets `applyPlanFile + checkDrift=true` (`workflows.go:3236-3243`) → runs `apply-plan.sh custom-stack-provision --plan-file <id> --check-drift`.
- `apply-with-outputs.sh` reaches `apply.sh` **only in simple mode** (no `--check-drift`); its `--check-drift` branch runs terraform directly with **no git ops**. `apply-plan.sh` has **no git ops at all**.

So ui-core always takes a branch that skips the push, and `gitPushInfra`'s silent `"Skipping … no infra remote"` no-op meant the apply still reported SUCCESS with an empty repo.

The design intent for `.git` + `repo_clone_ssh_url` reaching the apply tree is already satisfied: `prepare-custom-stack.sh::ensure_git_from_infra` clones the infra repo and moves `.git` into `MARS_PROJECT_ROOT`, and it runs immediately before `custom-stack-provision` in both the create sequence (`customStackSequence`) and the plan workflow (`makeCustomStackPlanWorkflow` always runs `prepare-custom-stack`), carried forward via the Argo `state-dir` artifact. The missing piece was purely that the apply command never invoked the helpers.

## Fix

All changes are in this repo (sandbox-infrastructure-template):

- **`shell_utils.sh`**
  - New `persistInfraRepo` = `gitMergeInfraMain + gitCommit + gitPushInfra`, **non-fatal and loud**.
  - `ensure_infra_remote` / `configure_git` / `gitPushInfra` now emit prominent, greppable `[git-infra] WARNING:` lines instead of silently returning 0 (covers issue hypotheses 1 & 2 — empty `repo_clone_ssh_url`, missing `.git`), plus a no-HEAD guard. Failures **warn but never fail an already-applied deploy** (conservative per the issue's guidance).
- **`tf/apply-with-outputs.sh`** (drift-check branch) and **`tf/apply-plan.sh`**: after a successful `terraform apply`, call `persistInfraRepo`, **scoped to the `custom-stack-provision` stage** — the stage that carries the full generated stack and has the infra `.git` + remote wired by `prepare-custom-stack`. `apply.sh` is left unchanged (still works for simple mode; no double-push).

## Architecture assumptions

- **Auto-var / `.git` ownership.** `tf/cloud-provision/repo.tf` creates the `<short>-infra` repo + deploy key and writes `tf/auto-vars/git_repo.auto.tfvars.json` (`repo_clone_ssh_url`). `prepare-custom-stack.sh::ensure_git_from_infra` owns materializing `.git` at `MARS_PROJECT_ROOT` (renames `origin` → `infra`).
- **State model = re-hydrated archive across Argo steps.** ui-core does not use a single long-lived working tree; each Argo step consumes the previous `state-dir` artifact (the whole `/marsproject`, incl. `.git` and `tf/auto-vars/`) from S3 (`{env}/artifacts/{projectID}.tar.gz`) and re-uploads it. On the saved-plan path (`makeApplyAllFromPlanWorkflow`) `prepare-custom-stack` is intentionally not re-run; the `.git` it produced in the plan workflow rides the artifact into the apply. This is why scoping the push to `custom-stack-provision` (rather than every apply stage) is correct — earlier stages have no `.git` yet.
- **Deploy safety over strictness.** The push path is loud-but-non-fatal; a git/remote/deploy-key problem produces a `[git-infra] WARNING:` and leaves the deploy successful, rather than bricking applies.
- **Backfill of the 89 existing empty repos is explicitly out of scope** (separate follow-up); this fixes forward-going applies.

## Tests

- **`tests/test-infra-push.sh`** (new, rsync-free): drives the real `apply-with-outputs.sh` / `apply-plan.sh` with a mock terraform + **real git** against a local bare infra repo. Asserts (i) a ref lands on the infra repo when the auto-var + `.git` are present; (ii) the loud `[git-infra] WARNING:` fires and the apply still exits 0 when either is absent; (iii) persist is scoped to `custom-stack-provision`; (iv) a re-deploy advances the repo. **19/19 pass.**
- Wired `test-infra-push.sh` + the previously-orphaned `test-apply-scripts.sh` and `test-drift-check.sh` (which gate the modified scripts) into `.github/workflows/validate.yml`.

Local results (this sandbox):

```
test-infra-push.sh      19 passed, 0 failed
test-apply-scripts.sh   63 passed, 0 failed   (no regression; lifecycle=default unaffected)
test-drift-check.sh    126 passed, 0 failed
```
Plus the full rsync-free suite (`test-tf-destroy-init`, `test-plan-all`, `test-{aws,gcp}-preflight`, `test-*-preflight-skip`, `test-external-id`, `test-state-backend-output-parity`, `test-mars-entrypoint-compat`, `test-reverse-import-wrapper`) all exit 0. `bash -n` + `shellcheck -x -S warning` clean over all 44 `.sh` files; `validate.yml` is valid YAML. `test-prepare-custom-stack.sh` needs `rsync` (absent in this sandbox) so it was not run here — it runs in CI.

## Verify after merge

A successful apply for a fresh project should leave `-infra` non-empty (`gh api repos/luthersystems/<short>-infra/commits` returns commits), and deploy logs will show `📦 [git-infra] Persisting …` → `✅ [git-infra] Pushed to infra remote`. A misconfigured tree instead surfaces a greppable `[git-infra] WARNING:` line instead of a silent success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR)_