### PR TITLE
feat(preflight): add iam:CreatePolicyVersion + iam:TagPolicy to REQUIRED_ACTIONS (and GCP iam.roles.{create,update} mirror)

### DIFF
--- a/tests/test-aws-preflight.sh
+++ b/tests/test-aws-preflight.sh
@@ -25,7 +25,7 @@ ROLE="arn:aws:iam::123456789012:role/insideout-bootstrap"
 # Full required set — must stay in sync with REQUIRED_ACTIONS in the script AND
 # with reliable bootstrap_permissions.go::bootstrapAWSIAMActions() (drift guard
 # below cross-checks the script against this literal).
-ALL_ACTIONS='["iam:AttachRolePolicy","iam:CreatePolicy","iam:CreateRole","iam:GetRole","iam:PassRole","iam:PutRolePolicy","iam:TagRole","kms:CreateAlias","kms:CreateKey","kms:DescribeKey","kms:PutKeyPolicy","kms:TagResource","s3:CreateBucket","s3:GetBucketVersioning","s3:PutBucketPolicy","s3:PutBucketPublicAccessBlock","s3:PutBucketVersioning","s3:PutEncryptionConfiguration","sts:AssumeRole","sts:GetCallerIdentity"]'
+ALL_ACTIONS='["iam:AttachRolePolicy","iam:CreatePolicy","iam:CreatePolicyVersion","iam:CreateRole","iam:GetRole","iam:PassRole","iam:PutRolePolicy","iam:TagPolicy","iam:TagRole","kms:CreateAlias","kms:CreateKey","kms:DescribeKey","kms:PutKeyPolicy","kms:TagResource","s3:CreateBucket","s3:GetBucketVersioning","s3:PutBucketPolicy","s3:PutBucketPublicAccessBlock","s3:PutBucketVersioning","s3:PutEncryptionConfiguration","sts:AssumeRole","sts:GetCallerIdentity"]'
 
 # simulate_response <jq-decision-expr> — emit an `aws iam simulate-principal-policy`
 # shaped JSON where each required action's EvalDecision is computed by the jq
@@ -77,16 +77,16 @@ else
 fi
 
 echo ""
-echo "Test 3: empty allowed list -> FAIL CLOSED, all 20 missing (exit 1)"
+echo "Test 3: empty allowed list -> FAIL CLOSED, all 22 missing (exit 1)"
 resp_empty="$WORKDIR/resp_empty.json"
 echo '{"EvaluationResults": []}' > "$resp_empty"
 run_preflight 1 "zero allowed fails closed" "$ROLE" \
   "AWS_PREFLIGHT_TEST_SIMULATE_FILE=$resp_empty"
 missing_lines="$(grep -c '^\[aws-preflight\]   - ' <<<"$OUT")"
-if [[ "$missing_lines" -eq 20 ]]; then
-  pass "lists all 20 missing actions"
+if [[ "$missing_lines" -eq 22 ]]; then
+  pass "lists all 22 missing actions"
 else
-  fail "expected 20 missing action lines, got $missing_lines"
+  fail "expected 22 missing action lines, got $missing_lines"
 fi
 
 echo ""
@@ -162,7 +162,7 @@ script_actions="$(grep -E '^[[:space:]]+(iam|kms|s3|sts):[A-Za-z]+$' "$PREFLIGHT
   | sort -u)"
 golden_actions="$(jq -r '.[]' <<<"$ALL_ACTIONS" | sort -u)"
 if [[ "$script_actions" == "$golden_actions" ]]; then
-  pass "REQUIRED_ACTIONS matches the 20-action golden set"
+  pass "REQUIRED_ACTIONS matches the 22-action golden set"
 else
   fail "REQUIRED_ACTIONS drifted from golden set"
   echo "--- script ---"; echo "$script_actions"

--- a/tests/test-gcp-preflight.sh
+++ b/tests/test-gcp-preflight.sh
@@ -20,7 +20,7 @@ WORKDIR="$(mktemp -d /tmp/test-gcp-preflight-XXXXXX)"
 trap 'rm -rf "$WORKDIR"' EXIT
 
 # Full required set — must stay in sync with REQUIRED_PERMISSIONS in the script.
-ALL_PERMS='["iam.serviceAccounts.create","iam.serviceAccounts.get","iam.serviceAccounts.getIamPolicy","iam.serviceAccounts.setIamPolicy","resourcemanager.projects.get","resourcemanager.projects.getIamPolicy","resourcemanager.projects.setIamPolicy","storage.buckets.create","storage.buckets.get","storage.buckets.update"]'
+ALL_PERMS='["iam.roles.create","iam.roles.update","iam.serviceAccounts.create","iam.serviceAccounts.get","iam.serviceAccounts.getIamPolicy","iam.serviceAccounts.setIamPolicy","resourcemanager.projects.get","resourcemanager.projects.getIamPolicy","resourcemanager.projects.setIamPolicy","storage.buckets.create","storage.buckets.get","storage.buckets.update"]'
 
 # run_preflight <expected_exit> <label> [extra env assignments...] -- writes the
 # combined output to $OUT and asserts the exit code.
@@ -50,7 +50,7 @@ echo ""
 echo "Test 2: missing the two #2243 create perms -> FAIL CLOSED (exit 1)"
 resp_partial="$WORKDIR/resp_partial.json"
 # Everything EXCEPT storage.buckets.create and iam.serviceAccounts.create.
-echo '{"permissions": ["iam.serviceAccounts.get","iam.serviceAccounts.getIamPolicy","iam.serviceAccounts.setIamPolicy","resourcemanager.projects.get","resourcemanager.projects.getIamPolicy","resourcemanager.projects.setIamPolicy","storage.buckets.get","storage.buckets.update"]}' > "$resp_partial"
+echo '{"permissions": ["iam.roles.create","iam.roles.update","iam.serviceAccounts.get","iam.serviceAccounts.getIamPolicy","iam.serviceAccounts.setIamPolicy","resourcemanager.projects.get","resourcemanager.projects.getIamPolicy","resourcemanager.projects.setIamPolicy","storage.buckets.get","storage.buckets.update"]}' > "$resp_partial"
 run_preflight 1 "missing create perms fails closed" \
   "GCP_PREFLIGHT_TEST_RESPONSE_FILE=$resp_partial" "GCP_PREFLIGHT_TEST_HTTP_CODE=200"
 if grep -q "storage.buckets.create" <<<"$OUT" && grep -q "iam.serviceAccounts.create" <<<"$OUT"; then
@@ -65,15 +65,15 @@ else
 fi
 
 echo ""
-echo "Test 3: empty granted list -> FAIL CLOSED, all 10 missing (exit 1)"
+echo "Test 3: empty granted list -> FAIL CLOSED, all 12 missing (exit 1)"
 resp_empty="$WORKDIR/resp_empty.json"
 echo '{"permissions": []}' > "$resp_empty"
 run_preflight 1 "zero perms fails closed" \
   "GCP_PREFLIGHT_TEST_RESPONSE_FILE=$resp_empty" "GCP_PREFLIGHT_TEST_HTTP_CODE=200"
-if [[ "$(grep -c '^\[gcp-preflight\]   - ' <<<"$OUT")" -eq 10 ]]; then
-  pass "lists all 10 missing permissions"
+if [[ "$(grep -c '^\[gcp-preflight\]   - ' <<<"$OUT")" -eq 12 ]]; then
+  pass "lists all 12 missing permissions"
 else
-  fail "expected 10 missing permission lines, got $(grep -c '^\[gcp-preflight\]   - ' <<<"$OUT")"
+  fail "expected 12 missing permission lines, got $(grep -c '^\[gcp-preflight\]   - ' <<<"$OUT")"
 fi
 
 echo ""
@@ -125,12 +125,12 @@ echo "Test 9: required list in script matches the golden set (drift guard)"
 # drifted from the mirrored reliable bootstrapGCPIAMPermissions() set. Extract
 # only whole-line array entries (indented token on its own line) so comment
 # fragments like "storage.buckets.{create,get,update}" cannot pollute the set.
-script_perms="$(grep -E '^[[:space:]]+(iam\.serviceAccounts|resourcemanager\.projects|storage\.buckets)\.[a-zA-Z]+$' "$PREFLIGHT" \
+script_perms="$(grep -E '^[[:space:]]+(iam\.roles|iam\.serviceAccounts|resourcemanager\.projects|storage\.buckets)\.[a-zA-Z]+$' "$PREFLIGHT" \
   | sed 's/^[[:space:]]*//' \
   | sort -u)"
 golden_perms="$(jq -r '.[]' <<<"$ALL_PERMS" | sort -u)"
 if [[ "$script_perms" == "$golden_perms" ]]; then
-  pass "REQUIRED_PERMISSIONS matches the 10-permission golden set"
+  pass "REQUIRED_PERMISSIONS matches the 12-permission golden set"
 else
   fail "REQUIRED_PERMISSIONS drifted from golden set"
   echo "--- script ---"; echo "$script_perms"

--- a/tf/aws-preflight.sh
+++ b/tf/aws-preflight.sh
@@ -125,16 +125,33 @@ set -uo pipefail
 #   iam:CreateRole / iam:GetRole / iam:TagRole / iam:PutRolePolicy /
 #   iam:AttachRolePolicy / iam:CreatePolicy / iam:PassRole
 #                                            admin terraform role + inspector role
+#   iam:CreatePolicyVersion / iam:TagPolicy  least-privilege companion (#147
+#                                            design §6(b)): once the deploy
+#                                            role's policy is the customer-
+#                                            managed InsideOutWrite policy,
+#                                            re-provision UPDATES it in place
+#                                            via iam:CreatePolicyVersion (not
+#                                            iam:CreatePolicy) and creation
+#                                            carries the Project tag via
+#                                            iam:TagPolicy. Without these a
+#                                            credential passes first-deploy
+#                                            preflight then 403s mid-apply on
+#                                            the NEXT re-provision — the #2243
+#                                            failure class relocated. Harmless
+#                                            today: admin roles trivially
+#                                            simulate-pass both.
 #   sts:AssumeRole                           admin role assumed by the terraform SA
 #   sts:GetCallerIdentity                    AWS provider init
 # ----------------------------------------------------------------------------
 REQUIRED_ACTIONS=(
   iam:AttachRolePolicy
   iam:CreatePolicy
+  iam:CreatePolicyVersion
   iam:CreateRole
   iam:GetRole
   iam:PassRole
   iam:PutRolePolicy
+  iam:TagPolicy
   iam:TagRole
   kms:CreateAlias
   kms:CreateKey

--- a/tf/gcp-preflight.sh
+++ b/tf/gcp-preflight.sh
@@ -84,8 +84,22 @@ set -uo pipefail
 #   iam.serviceAccounts.{get,set}IamPolicy   the two SA token-creator bindings
 #   resourcemanager.projects.get             provider project read
 #   resourcemanager.projects.{get,set}IamPolicy  the five project IAM bindings
+#   iam.roles.{create,update}                least-privilege companion (#147
+#                                            design §7/§7.3): once the
+#                                            roles/owner grant is replaced by a
+#                                            scoped custom role
+#                                            (google_project_iam_custom_role),
+#                                            cloud-provision must CREATE it on
+#                                            first apply and UPDATE its
+#                                            includedPermissions on
+#                                            re-provision. Harmless today: the
+#                                            Owner-grant check already gates
+#                                            GCP bootstrap, and Owner implies
+#                                            both permissions.
 # ----------------------------------------------------------------------------
 REQUIRED_PERMISSIONS=(
+  iam.roles.create
+  iam.roles.update
   iam.serviceAccounts.create
   iam.serviceAccounts.get
   iam.serviceAccounts.getIamPolicy


### PR DESCRIPTION
## Summary

Implements the preflight companion change from the #147 least-privilege design (`docs/design/least-privilege-deploy-role.md`, §6(b) and §7/§7.3). Refs #147 and luthersystems/reliable#2243 (no closing keywords intended).

- `tf/aws-preflight.sh` `REQUIRED_ACTIONS`: add `iam:CreatePolicyVersion` and `iam:TagPolicy`, next to `iam:CreatePolicy`
- `tf/gcp-preflight.sh` `REQUIRED_PERMISSIONS`: add `iam.roles.create` and `iam.roles.update` — the reciprocal of the same edit in reliable `bootstrapGCPIAMPermissions()`, keeping the declared "keep the two lists in sync" mirror honest
- `tests/test-aws-preflight.sh` / `tests/test-gcp-preflight.sh`: golden sets and count pins updated (20 to 22 actions, 10 to 12 permissions); the GCP drift-guard grep pattern now admits the `iam.roles.*` prefix

## Why

- The #147 design has the bootstrap credential create and attach the customer-managed `InsideOutWrite` policy. First provision is already covered, but re-provision after the policy widens calls `iam:CreatePolicyVersion` against the existing policy ARN, and creation carries the `Project` tag via `iam:TagPolicy`. Without them a credential passes first-deploy preflight then 403s mid-apply on the next re-provision — the reliable#2243 failure class relocated (design §6(b)).
- GCP (design §7/§7.3): once the `roles/owner` grant is replaced by a scoped custom role, cloud-provision must create/update it.

## Safety

- Additive and safe today: admin roles trivially simulate-pass the new AWS actions; the Owner-grant check already gates GCP and Owner implies the new permissions.

## Consumption path (verified)

- The live path delegates to the mars `insideout-preflight` binary, which receives the list via `--actions` (comma-joined from `REQUIRED_ACTIONS` at `tf/aws-preflight.sh` tier-2 dispatch) — the binary holds no list of its own, so it picks the new actions up automatically. The inline aws-cli implementation below it is the legacy fallback and reads the same array.
- ui-core's `aws_bootstrap_iam_preflight.go` likewise receives `requiredActions` from reliable's payload and holds no authored list — confirmed, matching design §6: two authored lists feeding three simulate call-sites. The reliable half of this change is the companion PR luthersystems/reliable#2259.
- The parity between the two authored lists remains convention (each header cites the other); each repo's own golden-set drift guard is updated here.

## Testing

- `bash -n` and `shellcheck -x -S warning` clean on all four touched scripts
- `tests/test-aws-preflight.sh`: 18 passed, 0 failed
- `tests/test-gcp-preflight.sh`: 14 passed, 0 failed
- `tests/test-preflight-binary-swap.sh`: 38 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR)_