### PR TITLE
feat(cloud-provision): wire terraform_role to InsideOutWrite + boundary via tf-modules v55.23.0 (#147 Phase 0 complete)

### DIFF
--- a/tf/cloud-provision/aws-resources.tf.tmpl
+++ b/tf/cloud-provision/aws-resources.tf.tmpl
@@ -10,9 +10,67 @@ locals {
 # AWS Bootstrap
 # ============================================================================
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Least-privilege deploy role — Phase 0 (issue #147), durable-role half:
+# docs/design/least-privilege-deploy-role.md §8.1 — "swap the role first,
+# tighten later". Mirrors tf/account-setup/main.tf (the bootstrap_role half,
+# merged in #157) for the durable `<short_project_id>-luther-terraform` role
+# provisioned by tf-modules//aws-platform-ui-bootstrap (inputs added in
+# tf-modules#71, released v55.23.0). PERMISSION-NEUTRAL by design:
+#
+#   * deploy_policy_json below is the same brand-new CUSTOMER-MANAGED
+#     InsideOutWrite body as account-setup's — Phase-0 content is
+#     admin-equivalent (Allow * on *), the same effective surface as the
+#     AWS-managed AdministratorAccess it replaces inside the module. Real
+#     deploys behave exactly as today; only the attached policy OBJECT (the
+#     identity) changes.
+#   * The role name/ARN is unchanged (the module keeps the attachment's
+#     resource address too — tf-modules#71 deliberately did not count-gate
+#     it), so every downstream consumer of `terraform_role` (the vm/k8s/
+#     custom-stack backend role_arn, cached STS/Oracle paths) and the #2243
+#     preflight — which simulates ACTIONS against the role ARN, never a
+#     policy name (design doc §6(a)/§6(c)) — keep working across the swap.
+#   * Rollback: set deploy_policy_json / permissions_boundary_arn back to ""
+#     (module defaults) and re-apply — the module re-attaches
+#     arn:aws:iam::aws:policy/AdministratorAccess and drops the boundary.
+#
+# Phase 2 later narrows only the BODY of the module-created policy (an
+# in-place CreatePolicyVersion — never a role/ARN change) to the
+# generator-owned allowlist kept as
+# tf/account-setup/policies/insideout-write.json. Do NOT wire that scoped
+# body yet: enforcement is gated on the §8.2 CloudTrail shadow phase and the
+# §6(b) preflight companion change (iam:CreatePolicyVersion / iam:TagPolicy).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Deny-only boundary body — read cross-stage from account-setup, whose
+# policies/insideout-deploy-boundary.json is the single source of truth for
+# BOTH deploy roles (it is generator-output; see
+# tf/account-setup/policies/README.md). The cross-stage file() is safe here:
+# the template repo is always one tree at plan time (CI checks out the whole
+# repo; at deploy time mars mounts the git root, and this stage already
+# writes cross-stage via local_file to ../vm-provision et al.). Deny-only ⇒
+# non-enforcing for real deploy usage; safe to attach in Phase 0 per design
+# doc §4 option 3 / §8.1.
+resource "aws_iam_policy" "insideout_deploy_boundary" {
+  name        = "${local.admin_role_name}-insideout-deploy-boundary"
+  description = "Deny-only permission boundary for the durable InsideOut terraform role (#147 Phase 0 defense-in-depth)."
+  policy      = file("${path.module}/../account-setup/policies/insideout-deploy-boundary.json")
+
+  # Tagged like the inspector role this stage creates. Tagging a policy at
+  # create time requires iam:TagPolicy, which the §6(b) preflight companion
+  # change covers: reliable#2259 (bootstrapAWSIAMActions, shipped in reliable
+  # v0.62.0) and template#158 (aws-preflight.sh REQUIRED_ACTIONS) both
+  # simulate it, so a credential that passes preflight can apply this change.
+  tags = {
+    Project   = var.project_id
+    ManagedBy = "terraform"
+    Purpose   = "insideout-deploy-boundary"
+  }
+}
+
 module "bootstrap" {
   count  = 1
-  source = "github.com/luthersystems/tf-modules.git//aws-platform-ui-bootstrap?ref=v55.15.2"
+  source = "github.com/luthersystems/tf-modules.git//aws-platform-ui-bootstrap?ref=v55.23.0"
 
   admin_role_name     = local.admin_role_name
   create_dns          = var.create_dns
@@ -23,6 +81,36 @@ module "bootstrap" {
   create_state_bucket = true
   admin_principals    = [var.terraform_sa_role]
   kms_alias_suffix    = format("%s-tfstate", var.short_project_id)
+
+  # #147 Phase 0: the customer-managed InsideOutWrite policy (admin-equivalent
+  # body, header comment above) replaces the module's AdministratorAccess
+  # attachment on the durable terraform role.
+  #
+  # The Phase-0 body is inline and admin-equivalent ON PURPOSE. The checked-in
+  # tf/account-setup/policies/insideout-write.json is the NARROWER
+  # generator-output placeholder for Phase 2 — inlining here (instead of
+  # file()-ing that JSON) keeps the scoped body un-attached until the
+  # shadow/audit phase validates it; wiring it early risks mid-apply 403s
+  # (the reliable#2243 failure class).
+  deploy_policy_json = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AdminEquivalentPhase0"
+        Effect   = "Allow"
+        Action   = "*"
+        Resource = "*"
+      }
+    ]
+  })
+
+  # #147 Phase 0 (design doc §8.1): deny-only permission boundary — a hard cap
+  # that removes only provably-out-of-scope surface (Organizations/Billing
+  # control plane, IAM users/login credentials, security-monitoring teardown).
+  # Strict superset of real deploy usage ⇒ effective permissions of a real
+  # deploy are unchanged. Rollback: set back to "" and re-apply — independent
+  # of the policy swap above.
+  permissions_boundary_arn = aws_iam_policy.insideout_deploy_boundary.arn
 
   providers = {
     aws    = aws


### PR DESCRIPTION
Phase 0 of #147 (design doc §8.1 — "swap the role first, tighten later") for the **second** deploy role: the durable `<short_project_id>-luther-terraform` role provisioned by the tf-modules `aws-platform-ui-bootstrap` module. Mirrors the merged `account-setup` bootstrap_role half (#157). With this, **Phase 0 is complete for BOTH roles**; Phases 1 (CloudTrail shadow) and 2 (chip-down) remain — referencing #147 without closing it.

## Scoped diff review: tf-modules `v55.15.2..v55.23.0`, `aws-platform-ui-bootstrap/` only

The pin bump changes only this module's fetched content, so this scoped diff is the full blast radius. Exactly **one commit** touches the module in that range — `414234b` (tf-modules#71) — touching `admin.tf` (+29/−2) and `vars.tf` (+18); no other files changed (`aws.tf`, `dns.tf`, `state.tf`, `versions.tf` untouched — no provider-requirement or output changes):

- **`vars.tf`**: two NEW variables, `deploy_policy_json` and `permissions_boundary_arn`, both `type = string`, both **`default = ""`** → no new required vars.
- **`admin.tf` — `aws_iam_role.admin`**: gains `permissions_boundary = var.permissions_boundary_arn != "" ? var.permissions_boundary_arn : null` → `null` (identical to before) when the input is unset.
- **`admin.tf` — NEW `aws_iam_policy.deploy`**: `count = var.deploy_policy_json != "" ? 1 : 0` → count 0 (no resource) when the input is unset. Named `${var.admin_role_name}-deploy`.
- **`admin.tf` — `aws_iam_role_policy_attachment.admin`**: `policy_arn` becomes conditional (`deploy` policy when `deploy_policy_json` is set, else the same `arn:aws:iam::aws:policy/AdministratorAccess`). Deliberately **NOT count-gated**, so the resource **address is preserved** for every existing consumer — no destroy/create of the attachment, and no plan diff when the inputs are unset.

**Verdict: pure no-op for existing consumers beyond the #71 inputs.** No renamed resources, no changed defaults, no new required variables, no output or provider-constraint changes. Safe to proceed.

## What this PR wires (in `tf/cloud-provision/aws-resources.tf.tmpl`)

1. **Pin bump** — ONLY the `aws-platform-ui-bootstrap` `?ref=` goes `v55.15.2` → `v55.23.0`. The other tf-modules pins (`aws-platform-ui-storage`, `aws-platform-ui-main`, `luthername` ×2) are untouched.
2. **`deploy_policy_json`** — the SAME inline admin-equivalent Phase-0 `InsideOutWrite` body as `tf/account-setup/main.tf` (`jsonencode` of `Allow */*`, Sid `AdminEquivalentPhase0`), with the same Phase-0/Phase-2 comments. The module now attaches a customer-managed policy object in place of the AWS-managed `AdministratorAccess`.
3. **Deny-only boundary** — new `aws_iam_policy.insideout_deploy_boundary` in cloud-provision, `file()`-read cross-stage from `tf/account-setup/policies/insideout-deploy-boundary.json` (the single source of truth for BOTH roles). Cross-stage paths resolve in this repo's layout: CI validates on a full checkout, mars mounts the git root at deploy time, and this stage already writes cross-stage via `local_file` to `../vm-provision` et al. Its ARN is passed as `permissions_boundary_arn`.
4. **GCP arm** — confirmed the module/role is AWS-only (the GCP analogue is the management SA's `roles/owner` grant in `gcp-resources.tf.tmpl`, tracked separately in the design doc §7). **No GCP changes.**

## Permission-neutrality invariant

The attached policy body still allows `*` on `*` — the same effective surface as the `AdministratorAccess` it replaces; only the policy **object** (the identity) changes. The boundary is deny-only over provably-out-of-scope surface (Organizations/Billing control plane, IAM users/credentials, security-monitoring teardown) — a strict superset of real deploy usage. The role name/ARN and the attachment's resource address are unchanged, so the vm/k8s/custom-stack backend `role_arn`, cached STS/Oracle paths, and the #2243 preflight (which simulates actions against the role ARN, never a policy name) all keep working.

## New provisions vs existing customers

- **NEW provisions**: get the customer-managed `<short>-luther-terraform-deploy` policy + `<short>-luther-terraform-insideout-deploy-boundary` boundary from the first apply — behaviorally identical to today.
- **EXISTING customers**: **nothing changes until re-provision.** The pin is only fetched on a fresh `terraform init`/apply of `cloud-provision` for that project (the natural re-provision boundary, design doc §8.3); on that re-apply the swap is an in-place attachment update + boundary attach, with no role replacement.

## Rollback

Revert the `?ref=` pin bump and the two inputs (module defaults `""` restore the `AdministratorAccess` attachment and drop the boundary) and re-apply — a pure attachment/identity revert, no permission-narrowing to unwind (§8.4).

## Verification

- `terraform fmt -check -recursive` (tf/) — clean, including the activated copy of the tmpl.
- `terraform init -backend=false && terraform validate` in `tf/cloud-provision` with the AWS templates activated — **module fetched at v55.23.0 with the new inputs present**; `validate` passes. Caveat: in the agent sandbox the `integrations/github` **provider** 403s through the proxy (known limitation), so the local validate ran with the github-provider surface (`repo.tf` + provider block) stripped in a throwaway copy — CI's `terraform-validate (cloud-provision)` job runs the full init/validate properly. Also confirmed `validate` genuinely evaluates the cross-stage `file()` (fails when the path is absent, passes when present). The pre-existing `managed_policy_arns` deprecation warnings are unchanged from main.
- All 18 `tests/*.sh` shell tests pass locally.
- No shell scripts touched (no `bash -n`/shellcheck deltas).

Refs #147 (Phases 1–2 remain open). Companion changes already landed: tf-modules#71 (released v55.23.0), template#157 (bootstrap_role half), template#158 + reliable#2259 (`iam:TagPolicy`/`iam:CreatePolicyVersion` preflight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR)_