### PR TITLE
security: exclude tfvars/outputs from -infra pushes; add secrets/ credential load path (phases 0-1, #160)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,56 @@ tf/*/*-resources.tf
 # strips the worktree before targz) and ui-core#382 (the .git history
 # bloat follow-up).
 .terraform/
+
+# ===========================================================================
+# sandbox-infrastructure-template#160 — keep deploy-time tfvars, cloud
+# credentials, and terraform outputs OUT of the per-project -infra repo.
+#
+# persistInfraRepo() (shell_utils.sh) runs `git add -A` against the -infra
+# clone after every custom-stack apply; `git add -A` honors .gitignore, so
+# anything matched here is never committed/pushed to the customer's -infra
+# GitHub repo. Every pipeline read of these files is on-disk (getTfVar /
+# terraform auto-load), so excluding them from git is zero-deployment-risk.
+# ===========================================================================
+
+# tf/auto-vars/ holds the deploy-time common.auto.tfvars.json (cloud
+# credentials + base64 archive blob), the repo_clone_ssh_url, skip_remote_state,
+# etc. — all written at apply time and all sensitive. Ignore the directory's
+# contents. Use `tf/auto-vars/*` (not `tf/auto-vars/`) so the repo's own
+# tracked, NON-secret scaffolding under vars/ can be re-included below — this is
+# git-idiomatic, not a weakening of the pattern (`*` covers the same direct
+# children). #160
+tf/auto-vars/*
+# Negation carve-out for the paths `git ls-files` shows tracked before #160:
+#   tf/auto-vars/vars/common/config.tfvars   (comment-only tfvars scaffold)
+#   tf/auto-vars/vars/default/README         (docs)
+# They are static, non-secret, and NOT written at deploy time (no script or CI
+# injects them), so keep them tracked rather than weakening the pattern. #160
+# NOTE: tf/auto-vars/common.auto.tfvars.json is deliberately NOT carved out —
+# it is the exact credentials/archive blob #160 exists to exclude, so
+# re-including it would reintroduce the leak. It stays tracked in THIS repo as a
+# harmless `{}` seed (gitignore never untracks) but is excluded from the -infra
+# push.
+!tf/auto-vars/vars/
+!tf/auto-vars/vars/**
+
+# Any *.auto.tfvars.json anywhere: the tf/auto-vars/ credential blob AND the
+# per-stage copies tfSetup drops into tf/<stage>/ (`cp -rf auto-vars/*`), plus
+# the Phase-1 secrets copy. Placed AFTER the vars/ carve-out so a stray
+# *.auto.tfvars.json under vars/ is still excluded. #160
+*.auto.tfvars.json
+
+# Terraform JSON backend config generated at deploy time. #160
+backend.tf.json
+
+# Saved terraform plan files (e.g. apply.tfplan, refresh.tfplan, <id>.tfplan). #160
+*.tfplan
+
+# outputs/ holds terraform outputs + drift.json + tfplan*.json written at apply
+# time (apply-with-outputs.sh / apply-plan.sh / drift-refresh.sh). #160
+outputs/
+
+# Phase-1 per-stage decrypted secrets copy tfSetup stages from
+# secrets/cloud-credentials.auto.tfvars.json. Belt-and-suspenders (already
+# matched by *.auto.tfvars.json above). #160
+tf/*/zz-secret.auto.tfvars.json

--- a/shell_utils.sh
+++ b/shell_utils.sh
@@ -48,7 +48,9 @@ mustGetAnsibleField() {
 AUTO_VARS_DIR="${MARS_PROJECT_ROOT}/tf/auto-vars"
 
 # getTfVar VAR_NAME
-#   Print the value of VAR_NAME from any JSON file in auto-vars/ or empty string if not found
+#   Print the value of VAR_NAME from any JSON file in auto-vars/ (or, as a
+#   fallback, the gitignored secrets/*.auto.tfvars.json credential drop) or
+#   empty string if not found.
 getTfVar() {
   local key="$1"
 
@@ -58,9 +60,20 @@ getTfVar() {
     exit 1
   fi
 
-  # jq filter to get the variable from any JSON file in the directory, first match wins
+  # jq filter to get the variable from any JSON file, first match wins.
+  #
+  # Scan order matters (#160): tf/auto-vars/*.json FIRST, so behavior is
+  # unchanged while ui-core still writes credentials into
+  # tf/auto-vars/common.auto.tfvars.json; THEN fall back to the gitignored
+  # secrets/*.auto.tfvars.json credential drop. secrets/ is excluded from the
+  # persistInfraRepo `git add -A` push, so credentials placed there never leak
+  # into the per-project -infra repo (unlike common.auto.tfvars.json). Absent or
+  # empty secrets/ is a silent no-op: the `[[ -e ]]` guard (existing style, no
+  # nullglob) skips the unexpanded glob, so nothing errors under callers' `set
+  # -euo pipefail` when secrets/ has no *.auto.tfvars.json (today's state).
   local result=""
-  for file in "$AUTO_VARS_DIR"/*.json; do
+  local file val
+  for file in "$AUTO_VARS_DIR"/*.json "$MARS_PROJECT_ROOT"/secrets/*.auto.tfvars.json; do
     # skip if no matching files
     [[ -e "$file" ]] || continue
 

--- a/tests/test-infra-push.sh
+++ b/tests/test-infra-push.sh
@@ -102,11 +102,17 @@ make_project() {
 environment: test
 EOF
   echo '{"cloud_provider": "aws"}' > "$proj/tf/auto-vars/common.auto.tfvars.json"
+  # Decoy deploy-time output artifact — must never ride the -infra push (#160).
+  echo '{"dummy": true}' > "$proj/outputs/dummy.json"
   cp "$REPO_ROOT/shell_utils.sh" "$proj/shell_utils.sh"
   cp "$REPO_ROOT/tf/utils.sh" "$proj/tf/utils.sh"
   cp "$REPO_ROOT/tf/drift-check.sh" "$proj/tf/drift-check.sh"
   cp "$REPO_ROOT/tf/apply-with-outputs.sh" "$proj/tf/apply-with-outputs.sh"
   cp "$REPO_ROOT/tf/apply-plan.sh" "$proj/tf/apply-plan.sh"
+  # Copy the repo's REAL .gitignore into the fixture so `git add -A` in
+  # persistInfraRepo honors the #160 denylist — this is what makes the Case G
+  # canary below actually exercise the exclusions rather than pass vacuously.
+  cp "$REPO_ROOT/.gitignore" "$proj/.gitignore"
   # Mock apply.sh (only reached by simple mode, which these tests don't use).
   printf '#!/usr/bin/env bash\necho "apply.sh $*" >> "%s"\n' "$CMD_LOG" > "$proj/tf/apply.sh"
   chmod +x "$proj/tf/apply.sh"
@@ -339,6 +345,90 @@ if [[ "$first_count" -ge 1 && "$second_count" -gt "$first_count" ]]; then
   pass "F: re-deploy added a new commit to the -infra repo ($first_count → $second_count)"
 else
   fail "F: re-deploy did not advance the -infra repo ($first_count → $second_count)"
+fi
+
+# =============================================================================
+echo ""
+echo "=== Case G: #160 canary — sensitive artifacts never reach the -infra repo ==="
+# =============================================================================
+# make_project copies the repo's real .gitignore into the fixture and drops
+# decoys (tf/auto-vars/common.auto.tfvars.json + outputs/dummy.json). Here we
+# additionally drop secrets/ credential files, a saved plan, a backend json, and
+# a per-stage tfvars copy, then run a real custom-stack apply and assert the
+# pushed tree carries NONE of them — the #143 push path must not leak the #160
+# artifacts. tfSetup also stages secrets/cloud-credentials.auto.tfvars.json into
+# tf/custom-stack-provision/zz-secret.auto.tfvars.json, so the *.auto.tfvars.json
+# assertion also covers the Phase-1 staged credential copy.
+PROJ="$(make_project projG)"
+BARE="$(fresh_bare)"
+set_repo_clone_url "$PROJ" "file://$BARE"   # writes a decoy tf/auto-vars/common.auto.tfvars.json
+init_project_git "$PROJ"
+
+# Decoy sensitive artifacts that MUST NOT be pushed to the -infra repo (#160):
+mkdir -p "$PROJ/secrets"
+echo '{"bootstrap_role":"arn:aws:iam::1:role/x","aws_external_id":"topsecret"}' \
+  > "$PROJ/secrets/cloud-credentials.auto.tfvars.json"
+echo 'deploy-key-material' > "$PROJ/secrets/infra_deploy_key.pem"
+mkdir -p "$PROJ/tf/custom-stack-provision"
+echo '{"cloud_provider":"aws"}' > "$PROJ/tf/custom-stack-provision/common.auto.tfvars.json"
+echo 'plan-bytes'              > "$PROJ/tf/custom-stack-provision/apply.tfplan"
+echo '{}'                      > "$PROJ/tf/custom-stack-provision/backend.tf.json"
+
+set +e
+outG="$(run_apply "$PROJ" apply-with-outputs.sh custom-stack-provision --check-drift)"
+rcG=$?
+set -e
+
+[[ "$rcG" -eq 0 ]] && pass "G: apply exits 0" || fail "G: expected exit 0, got $rcG. Output: $outG"
+
+# The push must have happened, else the tree-content assertions are vacuous.
+if [[ "$(bare_commit_count "$BARE")" -ge 1 ]]; then
+  pass "G: a ref landed on the -infra repo"
+else
+  fail "G: nothing pushed — canary would be vacuous. Output: $outG"
+fi
+
+# Enumerate the pushed tree once.
+pushed_tree="$(git -C "$BARE" ls-tree -r --name-only main 2>/dev/null || echo "")"
+
+# Sanity: a known-good, non-secret file IS present — proves the denylist did not
+# nuke the whole tree (i.e. the canary can actually observe a leak).
+if echo "$pushed_tree" | grep -qx "shell_utils.sh"; then
+  pass "G: known-good file (shell_utils.sh) is present in the pushed tree"
+else
+  fail "G: expected shell_utils.sh in the pushed tree. Tree: $pushed_tree"
+fi
+
+# The #160 canary assertions:
+if echo "$pushed_tree" | grep -q '\.auto\.tfvars\.json$'; then
+  fail "G: a *.auto.tfvars.json rode the -infra push (#160 leak). Tree: $pushed_tree"
+else
+  pass "G: NO *.auto.tfvars.json in the pushed tree"
+fi
+
+if echo "$pushed_tree" | grep -q '^outputs/'; then
+  fail "G: outputs/ rode the -infra push (#160 leak). Tree: $pushed_tree"
+else
+  pass "G: NO outputs/ directory in the pushed tree"
+fi
+
+if echo "$pushed_tree" | grep -q '^secrets/'; then
+  fail "G: secrets/ rode the -infra push (#160 leak). Tree: $pushed_tree"
+else
+  pass "G: NO secrets/ directory in the pushed tree"
+fi
+
+# Bonus coverage for the rest of the #160 denylist exercised by the decoys above.
+if echo "$pushed_tree" | grep -q '\.tfplan$'; then
+  fail "G: a *.tfplan rode the -infra push (#160 leak). Tree: $pushed_tree"
+else
+  pass "G: NO *.tfplan in the pushed tree"
+fi
+
+if echo "$pushed_tree" | grep -q 'backend\.tf\.json$'; then
+  fail "G: backend.tf.json rode the -infra push (#160 leak). Tree: $pushed_tree"
+else
+  pass "G: NO backend.tf.json in the pushed tree"
 fi
 
 # --- Summary -----------------------------------------------------------------

--- a/tf/utils.sh
+++ b/tf/utils.sh
@@ -34,6 +34,39 @@ tfSetup() {
   if [ -d "auto-vars" ]; then
     cp -rf auto-vars/* "${workspace}/" 2>/dev/null || true
   fi
+
+  # #160 Phase 1: stage the customer cloud credentials from the gitignored
+  # secrets/ dir into the stage working dir as a single auto-loaded tfvars file
+  # (zz-secret.auto.tfvars.json — the zz- prefix sorts it last so it overrides).
+  # Because secrets/ (and tf/*/zz-secret.auto.tfvars.json) are gitignored, this
+  # keeps credentials OFF the persistInfraRepo `git add -A` push — unlike
+  # common.auto.tfvars.json under tf/auto-vars/. tfSetup's CWD is tf/ (not the
+  # project root), so use the absolute $MARS_PROJECT_ROOT path. Multiple
+  # *.auto.tfvars.json cannot be concatenated (invalid JSON), so copy only the
+  # canonical cloud-credentials.auto.tfvars.json and warn on any other match.
+  # Guarded on MARS_PROJECT_ROOT being set (the real apply paths always export
+  # it before sourcing utils.sh; some narrow unit tests source utils.sh without
+  # it, and the original relative-only tfSetup never referenced it — so under
+  # `set -u` the unset case must stay a no-op). No-op when secrets/ is absent or
+  # has no tfvars (today's state): nullglob makes the loop body simply not run.
+  if [ -n "${MARS_PROJECT_ROOT:-}" ] && [ -d "${MARS_PROJECT_ROOT}/secrets" ]; then
+    local secrets_dir="${MARS_PROJECT_ROOT}/secrets"
+    local canonical="${secrets_dir}/cloud-credentials.auto.tfvars.json"
+    local sf staged=0
+    shopt -s nullglob
+    for sf in "${secrets_dir}"/*.auto.tfvars.json; do
+      if [ "$sf" = "$canonical" ]; then
+        cp -f "$sf" "${workspace}/zz-secret.auto.tfvars.json"
+        staged=1
+      else
+        echo "⚠️  [secrets] WARNING: ignoring non-canonical secrets tfvars '$sf' — only cloud-credentials.auto.tfvars.json is staged (concatenating multiple JSON tfvars is invalid). [sandbox-infrastructure-template#160]" >&2
+      fi
+    done
+    shopt -u nullglob
+    if [ "$staged" = 1 ]; then
+      echo "🔐 [secrets] staged secrets/cloud-credentials.auto.tfvars.json → ${workspace}/zz-secret.auto.tfvars.json [sandbox-infrastructure-template#160]"
+    fi
+  fi
 }
 
 tfSetup


### PR DESCRIPTION
Phases 0+1 of #160 — the provably zero-deployment-risk slice. Surfaced by the TF-bridge e2e (luthersystems/reliable#2286) and validated against every deploy path by an adversarial review.

## What leaks today

`persistInfraRepo` runs `git add -A` against the per-project `<8hex>-infra` clone after every custom-stack apply, committing `tf/auto-vars/common.auto.tfvars.json` (cloud credentials + base64 archive blob), per-stage tfvars copies, and `outputs/tfplan*.json` — into repos where the customer holds an admin invite.

## Changes

- **Phase 0 — `.gitignore` denylist:** `tf/auto-vars/*`, `*.auto.tfvars.json`, `backend.tf.json`, `*.tfplan`, `outputs/`, `tf/*/zz-secret.auto.tfvars.json`. `git add -A` honors `.gitignore` and never errors, and every pipeline read of these files is on-disk (`getTfVar` / terraform auto-load) — so excluding them from git is zero-deployment-risk. `tf/auto-vars/common.auto.tfvars.json` is deliberately **not** carved back in (it's the leak target); the two tracked non-secret scaffolding files under `vars/` get a `!` negation exception.
- **Phase 1 — `secrets/` credential load path (inert until ui-core Phase 3):** `getTfVar` scans `tf/auto-vars/` first then falls back to `secrets/*.auto.tfvars.json` (behavior unchanged today); `tfSetup` stages `secrets/cloud-credentials.auto.tfvars.json` into each stage dir as `zz-secret.auto.tfvars.json`. `secrets/` is already gitignored and rides the S3 project archive, so this is where creds move in Phase 3 — off the git push.
- **Canary test — `tests/test-infra-push.sh` Case G:** drops real decoy secrets + tfplan + backend.tf.json, runs a real apply, asserts the pushed tree contains `shell_utils.sh` but **no** `*.auto.tfvars.json` / `outputs/` / `secrets/`. Non-vacuous by construction.

## Not in this PR (later, coupled phases)

- Phase 2: bump `SandboxTemplateRef` in reliable to consume this (the stage test).
- Phase 3 (ui-core): route creds to `secrets/`, delete raw AWS key writes, add the `archive.args()` merged view (mandatory — else GCP project-scoped/drift redeploys lose creds).
- The `aws_external_id → terraform_data` move was **dropped** on review (durable-ready redeploys skip cloud-provision, so the state output never materializes and the remote-state read hard-errors).

## Testing

- `bash -n` + `shellcheck -x -S warning` clean on all scripts
- `tests/test-infra-push.sh` 27/27 (8 new Case G asserts); full local test suite green
- `git add -A` ground-truth on a fresh repo confirms the denylist excludes creds/outputs/tfplan and keeps the non-secret tree

Refs luthersystems/reliable#2286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VV88uuWhoctc8NAY5KGqbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01VV88uuWhoctc8NAY5KGqbr)_